### PR TITLE
Flytt processName til egen header-bar over full bredde

### DIFF
--- a/app/routes/behandling/$behandlingId.module.css
+++ b/app/routes/behandling/$behandlingId.module.css
@@ -8,6 +8,11 @@
   max-width: 305px;
 }
 
+.processNameBar {
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+  padding: 0.5rem 3rem;
+}
+
 @media (min-width: 1440px) {
   .resposiveBorder {
     border-right-width: 1px;

--- a/app/routes/behandling/$behandlingId.test.tsx
+++ b/app/routes/behandling/$behandlingId.test.tsx
@@ -4,6 +4,8 @@ import { AktivitetStatus, AldeBehandlingStatus, BehandlingStatus } from '~/types
 import { getRedirectPath } from './$behandlingId'
 
 const mockBehandling: BehandlingDTO = {
+  processName: 'Del-automatisk førstegangsbehandling',
+  sakType: 'Alder',
   behandlingId: 123,
   sakId: 456,
   kravId: 789,
@@ -124,6 +126,7 @@ describe('getRedirectPath', () => {
             antallGangerKjort: 0,
             sisteAktiveringsdato: '2024-01-01T10:00:00Z',
             utsattTil: null,
+            behandletFerdigMaskinelt: false,
           },
         ],
       },
@@ -151,6 +154,7 @@ describe('getRedirectPath', () => {
             antallGangerKjort: 0,
             sisteAktiveringsdato: '2024-01-01T10:00:00Z',
             utsattTil: null,
+            behandletFerdigMaskinelt: false,
           },
         ],
       },
@@ -178,6 +182,7 @@ describe('getRedirectPath', () => {
             antallGangerKjort: 0,
             sisteAktiveringsdato: '2024-01-01T10:00:00Z',
             utsattTil: null,
+            behandletFerdigMaskinelt: false,
           },
         ],
       },
@@ -205,6 +210,7 @@ describe('getRedirectPath', () => {
             antallGangerKjort: 0,
             sisteAktiveringsdato: '2024-01-01T10:00:00Z',
             utsattTil: null,
+            behandletFerdigMaskinelt: false,
           },
         ],
       },
@@ -232,6 +238,7 @@ describe('getRedirectPath', () => {
             antallGangerKjort: 0,
             sisteAktiveringsdato: '2024-01-01T10:00:00Z',
             utsattTil: null,
+            behandletFerdigMaskinelt: false,
           },
         ],
       },

--- a/app/routes/behandling/$behandlingId.tsx
+++ b/app/routes/behandling/$behandlingId.tsx
@@ -450,6 +450,12 @@ export default function Behandling({ loaderData }: Route.ComponentProps) {
             </Box.New>
           )}
 
+          <div className={behandlingStyles.processNameBar}>
+            <BodyShort as="h2" size="small" weight="semibold">
+              {behandling.processName}
+            </BodyShort>
+          </div>
+
           <HStack justify="start" wrap={false}>
             <Show asChild above="2xl">
               <Box.New
@@ -458,13 +464,7 @@ export default function Behandling({ loaderData }: Route.ComponentProps) {
                 className={behandlingStyles.pennyVenstremenyBredde}
               >
                 <VStack>
-                  <Box.New paddingBlock="space-24" paddingInline="space-44">
-                    <BodyShort as="h2" size="small" weight="semibold">
-                      {behandling.processName}
-                    </BodyShort>
-                  </Box.New>
-
-                  <Box.New paddingBlock="space-12" paddingInline="space-44">
+                  <Box.New paddingBlock="space-32" paddingInline="space-44">
                     <Process hideStatusText={true}>
                       {allSteps
                         .filter(it => showStepper || it.handlerName)


### PR DESCRIPTION
Flytter behandlingens processName fra venstre-sidemenyen til en egen bar under metadata-seksjonen, slik at den vises over hele bredden uavhengig av skjermstørrelse.