### PR TITLE
Fix/improve page layout

### DIFF
--- a/app/behandlinger/alderspensjon-soknad/livsvarig-afp-offentlig/AfpLivsvarigVenter.tsx
+++ b/app/behandlinger/alderspensjon-soknad/livsvarig-afp-offentlig/AfpLivsvarigVenter.tsx
@@ -51,10 +51,10 @@ export function AfpLivsvarigVenter({
             </BodyShort>
           </VStack>
         </VStack>
-        <HStack gap="2" justify="center">
+        <VStack gap="2" align="center">
           {pensjonsoversiktUrl && <Link href={pensjonsoversiktUrl}>Pensjonsoversikt</Link>}
           {psakOppgaveoversikt && <Link href={psakOppgaveoversikt}>Oppgavelisten</Link>}
-        </HStack>
+        </VStack>
         {avbrytAktivitet && (
           <div>
             <Button as="a" size="small" variant="tertiary" onClick={avbrytAktivitet}>

--- a/app/behandlinger/alderspensjon-soknad/send-til-attestering/index.tsx
+++ b/app/behandlinger/alderspensjon-soknad/send-til-attestering/index.tsx
@@ -46,7 +46,7 @@ export default function SendTilAttesteringRoute() {
         </Heading>
 
         <Form method="post">
-          <HStack gap="2" justify="center">
+          <VStack gap="2" align="center">
             <Button type="submit" variant="primary" size="small">
               Send til attestering
             </Button>
@@ -54,7 +54,7 @@ export default function SendTilAttesteringRoute() {
             <Button type="button" variant="tertiary" size="small" onClick={avbrytAktivitet}>
               Avbryt del-auto behandling
             </Button>
-          </HStack>
+          </VStack>
         </Form>
       </VStack>
     </Page.Block>

--- a/app/common.module.css
+++ b/app/common.module.css
@@ -1,5 +1,10 @@
 .page {
   padding-top: var(--ax-space-56);
+  padding-bottom: var(--ax-space-56);
+}
+
+.behandlingPage {
+  padding-block: var(--ax-space-32);
 }
 
 .center {

--- a/app/components/shared/aktivitet-vurdering-layout.css
+++ b/app/components/shared/aktivitet-vurdering-layout.css
@@ -1,25 +1,32 @@
+.aktivitet {
+  display: flex;
+  flex-direction: column;
+}
+
 .aktivitet-vurdering-layout {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
 
   .header {
     padding: 0 2rem 2rem 0rem;
   }
 
   .grid {
-    flex: 1 auto;
+    flex: 1;
     display: grid;
-    grid-template-columns: auto 20em;
+    grid-template-columns: 1fr 24rem;
   }
 
   .sidebar {
-    margin: 0 1em;
+    padding-block: var(--ax-space-32);
+    padding-inline: var(--ax-space-32);
   }
 
   .main {
     border-right: 1px solid var(--ax-border-neutral-subtleA);
-    padding-right: var(--ax-space-20);
+    padding-inline: var(--ax-space-24);
+    padding-block: var(--ax-space-32);
   }
 
   .details-divider {

--- a/app/components/shared/aktivitet-vurdering-layout.css
+++ b/app/components/shared/aktivitet-vurdering-layout.css
@@ -1,9 +1,14 @@
 .aktivitet {
+  --aktivitet-gutter: var(--ax-space-16);
+
   display: flex;
   flex-direction: column;
+  padding-inline-start: var(--aktivitet-gutter);
 }
 
 .aktivitet-vurdering-layout {
+  --aktivitet-gutter: var(--ax-space-16);
+
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -25,12 +30,19 @@
 
   .main {
     border-right: 1px solid var(--ax-border-neutral-subtleA);
-    padding-inline: var(--ax-space-24);
+    padding-inline-end: var(--aktivitet-gutter);
     padding-block: var(--ax-space-32);
   }
 
   .details-divider {
     height: 1px;
     margin: 1em 0;
+  }
+}
+
+@media (min-width: 1024px) {
+  .aktivitet,
+  .aktivitet-vurdering-layout {
+    --aktivitet-gutter: var(--ax-space-48);
   }
 }

--- a/app/mocks/TESTABLE_ROUTES.md
+++ b/app/mocks/TESTABLE_ROUTES.md
@@ -1,0 +1,43 @@
+# Testable Routes (Mock Mode)
+
+Start the mock server with `npm run dev:mock`.
+
+## Aktiviteter
+
+| Route | Behandling | Status |
+|-------|------------|--------|
+| [/behandling/1000001/aktivitet/6020943/alderspensjon-soknad/vurder-samboer](http://localhost:3001/behandling/1000001/aktivitet/6020943/alderspensjon-soknad/vurder-samboer) | 1000001 | Aktiv aktivitet |
+| [/behandling/1000002/aktivitet/7020942/alderspensjon-soknad/kontroller-inntektsopplysninger-for-eps](http://localhost:3001/behandling/1000002/aktivitet/7020942/alderspensjon-soknad/kontroller-inntektsopplysninger-for-eps) | 1000002 | Aktiv aktivitet |
+| [/behandling/3000001/aktivitet/8010003/alderspensjon-soknad/send-til-attestering](http://localhost:3001/behandling/3000001/aktivitet/8010003/alderspensjon-soknad/send-til-attestering) | 3000001 | Aktiv aktivitet |
+| [/behandling/3000002/aktivitet/8020002/alderspensjon-soknad/livsvarig-afp-offentlig](http://localhost:3001/behandling/3000002/aktivitet/8020002/alderspensjon-soknad/livsvarig-afp-offentlig) | 3000002 | Aktiv aktivitet |
+
+## Attestering
+
+| Route | Behandling | aldeBehandlingStatus |
+|-------|------------|----------------------|
+| [/behandling/6359437](http://localhost:3001/behandling/6359437) | 6359437 | VENTER_ATTESTERING |
+
+## Statussider
+
+| Route | Behandling | aldeBehandlingStatus |
+|-------|------------|----------------------|
+| [/behandling/2000001/venter-attestering](http://localhost:3001/behandling/2000001/venter-attestering) | 2000001 | VENTER_ATTESTERING |
+| [/behandling/2000001/attestering-returnert-til-saksbehandler](http://localhost:3001/behandling/2000001/attestering-returnert-til-saksbehandler) | 2000001 | VENTER_ATTESTERING |
+| [/behandling/2000002/avbrutt-automatisk](http://localhost:3001/behandling/2000002/avbrutt-automatisk) | 2000002 | AUTOMATISK_TIL_MANUELL |
+| [/behandling/2000003/avbrutt-manuelt](http://localhost:3001/behandling/2000003/avbrutt-manuelt) | 2000003 | AVBRUTT_AV_BRUKER |
+| [/behandling/2000004/attestert-og-iverksatt](http://localhost:3001/behandling/2000004/attestert-og-iverksatt) | 2000004 | FULLFORT |
+| [/behandling/2000004/oppsummering](http://localhost:3001/behandling/2000004/oppsummering) | 2000004 | FULLFORT |
+
+## Mock Data Files
+
+| File | behandlingId | aldeBehandlingStatus |
+|------|-------------|----------------------|
+| `behandling-1000001.json` | 1000001 | UNDER_BEHANDLING |
+| `behandling-1000002.json` | 1000002 | UNDER_BEHANDLING |
+| `behandling-2000001.json` | 2000001 | VENTER_ATTESTERING |
+| `behandling-2000002.json` | 2000002 | AUTOMATISK_TIL_MANUELL |
+| `behandling-2000003.json` | 2000003 | AVBRUTT_AV_BRUKER |
+| `behandling-2000004.json` | 2000004 | FULLFORT |
+| `behandling-3000001.json` | 3000001 | UNDER_BEHANDLING |
+| `behandling-3000002.json` | 3000002 | UNDER_BEHANDLING |
+| `behandling-6359437.json` | 6359437 | VENTER_ATTESTERING |

--- a/app/mocks/data/aktivitet/8020002-grunnlagsdata.json
+++ b/app/mocks/data/aktivitet/8020002-grunnlagsdata.json
@@ -1,0 +1,22 @@
+{
+  "afpOffentligStatus": [
+    {
+      "status": "soknad",
+      "tpInfo": {
+        "tpNummer": 3100,
+        "tpNavn": "Statens pensjonskasse"
+      },
+      "onsketVirkningsdato": "2025-08-01"
+    }
+  ],
+  "grunnbelop": [
+    {
+      "fomDato": "2025-05-01",
+      "grunnbelop": 130000
+    },
+    {
+      "fomDato": "2024-05-01",
+      "grunnbelop": 124028
+    }
+  ]
+}

--- a/app/mocks/data/behandling-1000001.json
+++ b/app/mocks/data/behandling-1000001.json
@@ -3,6 +3,7 @@
   "type": "FleksibelApSakBehandling",
   "handlerName": "alderspensjon-soknad",
   "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "processName": "Alderspensjon søknad",
   "aldeBehandlingStatus": "VENTER_SAKSBEHANDLER",
   "sisteKjoring": null,
   "sisteKjoringDato": "2025-01-15T16:49:34.37642",

--- a/app/mocks/data/behandling-1000002.json
+++ b/app/mocks/data/behandling-1000002.json
@@ -3,6 +3,7 @@
   "type": "FleksibelApSakBehandling",
   "handlerName": "alderspensjon-soknad",
   "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "processName": "Alderspensjon søknad",
   "aldeBehandlingStatus": "VENTER_SAKSBEHANDLER",
   "sisteKjoring": null,
   "sisteKjoringDato": "2025-01-15T16:49:34.37642",

--- a/app/mocks/data/behandling-2000001.json
+++ b/app/mocks/data/behandling-2000001.json
@@ -1,0 +1,47 @@
+{
+  "behandlingId": 2000001,
+  "type": "FleksibelApSakBehandling",
+  "handlerName": "alderspensjon-soknad",
+  "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "aldeBehandlingStatus": "VENTER_ATTESTERING",
+  "sisteKjoring": null,
+  "sisteKjoringDato": "2025-01-15T16:49:34.37642",
+  "utsattTil": null,
+  "opprettet": "2025-01-15T16:49:29.7398",
+  "stoppet": null,
+  "status": "UNDER_BEHANDLING",
+  "sisteSaksbehandlerNavident": "Z990000",
+  "processName": "Alderspensjon søknad",
+  "aktiviteter": [
+    {
+      "aktivitetId": 8020942,
+      "type": "FleksibelApSakA203VurderInntektForEpsAktivitet",
+      "handlerName": "kontroller-inntektsopplysninger-for-eps",
+      "friendlyName": "Kontroller inntektsopplysninger for EPS",
+      "opprettet": "2025-01-15T16:49:34.364857",
+      "antallGangerKjort": 1,
+      "sisteAktiveringsdato": "2025-01-15T16:49:34.380546",
+      "status": "FULLFORT",
+      "utsattTil": null
+    },
+    {
+      "aktivitetId": 8020943,
+      "type": "FleksibelApSakA200VurderSamboerAktivitet",
+      "opprettet": "2025-01-15T16:49:34.364857",
+      "handlerName": "vurder-samboer",
+      "friendlyName": "Vurder samboer",
+      "antallGangerKjort": 1,
+      "sisteAktiveringsdato": "2025-01-15T16:49:34.380546",
+      "status": "FULLFORT",
+      "utsattTil": null
+    }
+  ],
+  "fnr": "12345678901",
+  "sakId": 23077283,
+  "kravId": 46365419,
+  "fornavn": "Ola",
+  "mellomnavn": null,
+  "etternavn": "Nordmann",
+  "fodselsdato": "1962-03-15",
+  "sakType": "ALDER"
+}

--- a/app/mocks/data/behandling-2000002.json
+++ b/app/mocks/data/behandling-2000002.json
@@ -1,0 +1,23 @@
+{
+  "behandlingId": 2000002,
+  "type": "FleksibelApSakBehandling",
+  "handlerName": "alderspensjon-soknad",
+  "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "aldeBehandlingStatus": "AUTOMATISK_TIL_MANUELL",
+  "sisteKjoring": null,
+  "sisteKjoringDato": "2025-01-15T16:49:34.37642",
+  "utsattTil": null,
+  "opprettet": "2025-01-15T16:49:29.7398",
+  "stoppet": null,
+  "status": "UNDER_BEHANDLING",
+  "processName": "Alderspensjon søknad",
+  "aktiviteter": [],
+  "fnr": "12345678901",
+  "sakId": 23077283,
+  "kravId": 46365419,
+  "fornavn": "Ola",
+  "mellomnavn": null,
+  "etternavn": "Nordmann",
+  "fodselsdato": "1962-03-15",
+  "sakType": "ALDER"
+}

--- a/app/mocks/data/behandling-2000003.json
+++ b/app/mocks/data/behandling-2000003.json
@@ -1,0 +1,23 @@
+{
+  "behandlingId": 2000003,
+  "type": "FleksibelApSakBehandling",
+  "handlerName": "alderspensjon-soknad",
+  "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "aldeBehandlingStatus": "AVBRUTT_AV_BRUKER",
+  "sisteKjoring": null,
+  "sisteKjoringDato": "2025-01-15T16:49:34.37642",
+  "utsattTil": null,
+  "opprettet": "2025-01-15T16:49:29.7398",
+  "stoppet": null,
+  "status": "UNDER_BEHANDLING",
+  "processName": "Alderspensjon søknad",
+  "aktiviteter": [],
+  "fnr": "12345678901",
+  "sakId": 23077283,
+  "kravId": 46365419,
+  "fornavn": "Ola",
+  "mellomnavn": null,
+  "etternavn": "Nordmann",
+  "fodselsdato": "1962-03-15",
+  "sakType": "ALDER"
+}

--- a/app/mocks/data/behandling-2000004.json
+++ b/app/mocks/data/behandling-2000004.json
@@ -1,0 +1,46 @@
+{
+  "behandlingId": 2000004,
+  "type": "FleksibelApSakBehandling",
+  "handlerName": "alderspensjon-soknad",
+  "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "aldeBehandlingStatus": "FULLFORT",
+  "sisteKjoring": null,
+  "sisteKjoringDato": "2025-01-15T16:49:34.37642",
+  "utsattTil": null,
+  "opprettet": "2025-01-15T16:49:29.7398",
+  "stoppet": null,
+  "status": "FULLFORT",
+  "processName": "Alderspensjon søknad",
+  "aktiviteter": [
+    {
+      "aktivitetId": 9020942,
+      "type": "FleksibelApSakA203VurderInntektForEpsAktivitet",
+      "handlerName": "kontroller-inntektsopplysninger-for-eps",
+      "friendlyName": "Kontroller inntektsopplysninger for EPS",
+      "opprettet": "2025-01-15T16:49:34.364857",
+      "antallGangerKjort": 1,
+      "sisteAktiveringsdato": "2025-01-15T16:49:34.380546",
+      "status": "FULLFORT",
+      "utsattTil": null
+    },
+    {
+      "aktivitetId": 9020943,
+      "type": "FleksibelApSakA200VurderSamboerAktivitet",
+      "opprettet": "2025-01-15T16:49:34.364857",
+      "handlerName": "vurder-samboer",
+      "friendlyName": "Vurder samboer",
+      "antallGangerKjort": 1,
+      "sisteAktiveringsdato": "2025-01-15T16:49:34.380546",
+      "status": "FULLFORT",
+      "utsattTil": null
+    }
+  ],
+  "fnr": "12345678901",
+  "sakId": 23077283,
+  "kravId": 46365419,
+  "fornavn": "Ola",
+  "mellomnavn": null,
+  "etternavn": "Nordmann",
+  "fodselsdato": "1962-03-15",
+  "sakType": "ALDER"
+}

--- a/app/mocks/data/behandling-3000001.json
+++ b/app/mocks/data/behandling-3000001.json
@@ -3,6 +3,7 @@
   "type": "FleksibelApSakBehandling",
   "handlerName": "alderspensjon-soknad",
   "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "processName": "Alderspensjon søknad",
   "aldeBehandlingStatus": "VENTER_SAKSBEHANDLER",
   "sisteKjoring": null,
   "sisteKjoringDato": "2025-03-10T10:30:00.000000",

--- a/app/mocks/data/behandling-3000001.json
+++ b/app/mocks/data/behandling-3000001.json
@@ -1,0 +1,55 @@
+{
+  "behandlingId": 3000001,
+  "type": "FleksibelApSakBehandling",
+  "handlerName": "alderspensjon-soknad",
+  "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "aldeBehandlingStatus": "VENTER_SAKSBEHANDLER",
+  "sisteKjoring": null,
+  "sisteKjoringDato": "2025-03-10T10:30:00.000000",
+  "utsattTil": null,
+  "opprettet": "2025-03-10T10:25:00.000000",
+  "stoppet": null,
+  "status": "UNDER_BEHANDLING",
+  "aktiviteter": [
+    {
+      "aktivitetId": 8010001,
+      "type": "FleksibelApSakA200VurderSamboerAktivitet",
+      "handlerName": "vurder-samboer",
+      "friendlyName": "Vurder samboer",
+      "opprettet": "2025-03-10T10:25:00.000000",
+      "antallGangerKjort": 1,
+      "sisteAktiveringsdato": "2025-03-10T10:30:00.000000",
+      "status": "FULLFORT",
+      "utsattTil": null
+    },
+    {
+      "aktivitetId": 8010002,
+      "type": "FleksibelApSakA203VurderInntektForEpsAktivitet",
+      "handlerName": "kontroller-inntektsopplysninger-for-eps",
+      "friendlyName": "Kontroller inntektsopplysninger for EPS",
+      "opprettet": "2025-03-10T10:25:00.000000",
+      "antallGangerKjort": 1,
+      "sisteAktiveringsdato": "2025-03-10T10:30:00.000000",
+      "status": "FULLFORT",
+      "utsattTil": null
+    },
+    {
+      "aktivitetId": 8010003,
+      "type": "FleksibelApSakSendTilAttesteringAktivitet",
+      "handlerName": "send-til-attestering",
+      "friendlyName": "Send til attestering",
+      "opprettet": "2025-03-10T10:25:00.000000",
+      "antallGangerKjort": 0,
+      "sisteAktiveringsdato": "2025-03-10T10:35:00.000000",
+      "status": "UNDER_BEHANDLING",
+      "utsattTil": null
+    }
+  ],
+  "fnr": "12345678901",
+  "sakId": 23077283,
+  "kravId": 46365419,
+  "fornavn": "Ola",
+  "mellomnavn": null,
+  "etternavn": "Nordmann",
+  "fodselsdato": "1962-03-15"
+}

--- a/app/mocks/data/behandling-3000002.json
+++ b/app/mocks/data/behandling-3000002.json
@@ -3,6 +3,7 @@
   "type": "FleksibelApSakBehandling",
   "handlerName": "alderspensjon-soknad",
   "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "processName": "Alderspensjon søknad",
   "aldeBehandlingStatus": "VENTER_SAKSBEHANDLER",
   "sisteKjoring": null,
   "sisteKjoringDato": "2025-04-01T09:00:00.000000",

--- a/app/mocks/data/behandling-3000002.json
+++ b/app/mocks/data/behandling-3000002.json
@@ -1,0 +1,44 @@
+{
+  "behandlingId": 3000002,
+  "type": "FleksibelApSakBehandling",
+  "handlerName": "alderspensjon-soknad",
+  "friendlyName": "Førstegangsbehandling av alderspensjonssøknad",
+  "aldeBehandlingStatus": "VENTER_SAKSBEHANDLER",
+  "sisteKjoring": null,
+  "sisteKjoringDato": "2025-04-01T09:00:00.000000",
+  "utsattTil": null,
+  "opprettet": "2025-04-01T08:50:00.000000",
+  "stoppet": null,
+  "status": "UNDER_BEHANDLING",
+  "aktiviteter": [
+    {
+      "aktivitetId": 8020001,
+      "type": "FleksibelApSakA201SettBrukPaRettPersongrunnlagAktivitet",
+      "handlerName": null,
+      "friendlyName": "Sett bruk på rett persongrunnlag",
+      "opprettet": "2025-04-01T08:50:00.000000",
+      "antallGangerKjort": 1,
+      "sisteAktiveringsdato": "2025-04-01T08:55:00.000000",
+      "status": "FULLFORT",
+      "utsattTil": null
+    },
+    {
+      "aktivitetId": 8020002,
+      "type": "FleksibelApSakAfpOffentligAktivitet",
+      "handlerName": "livsvarig-afp-offentlig",
+      "friendlyName": "Livsvarig AFP offentlig",
+      "opprettet": "2025-04-01T08:50:00.000000",
+      "antallGangerKjort": 1,
+      "sisteAktiveringsdato": "2025-04-01T09:00:00.000000",
+      "status": "UNDER_BEHANDLING",
+      "utsattTil": "2025-04-08T09:00:00.000000"
+    }
+  ],
+  "fnr": "12345678901",
+  "sakId": 23077283,
+  "kravId": 46365420,
+  "fornavn": "Kari",
+  "mellomnavn": null,
+  "etternavn": "Hansen",
+  "fodselsdato": "1963-07-22"
+}

--- a/app/mocks/data/behandling-6359437.json
+++ b/app/mocks/data/behandling-6359437.json
@@ -95,5 +95,7 @@
   "fornavn": "Ola",
   "mellomnavn": null,
   "etternavn": "Nordmann",
-  "fodselsdato": "1962-03-15"
+  "fodselsdato": "1962-03-15",
+  "sakType": "ALDER",
+  "processName": "Alderspensjon søknad"
 }

--- a/app/mocks/server.ts
+++ b/app/mocks/server.ts
@@ -56,48 +56,87 @@ const handlers = [
     return HttpResponse.text('Behandling not found', { status: 404 })
   }),
 
+  // Dynamic mock: loads behandling by ID and builds attestering data from its actual aktiviteter
   // GET /api/saksbehandling/alde/behandling/:id/attesteringsdata
-  http.get('*/api/saksbehandling/alde/behandling/:id/attesteringsdata', ({ request }) => {
+  http.get('*/api/saksbehandling/alde/behandling/:id/attesteringsdata', ({ params, request }) => {
+    const { id } = params
     console.log(`🎯 MSW intercepted attestering request to: ${request.url}`)
 
-    // Mock attestering data
+    // Load behandling and find relevant aktiviteter by handlerName
+    const behandling = loadMockData(`behandling-${id}.json`)
+    const aktiviteter = behandling?.aktiviteter ?? []
+
+    const epsAktivitet = aktiviteter.find(
+      (a: { handlerName?: string }) => a.handlerName === 'kontroller-inntektsopplysninger-for-eps',
+    )
+    const samboerAktivitet = aktiviteter.find((a: { handlerName?: string }) => a.handlerName === 'vurder-samboer')
+
+    // Build attestering data, only includes aktiviteter present in the behandling
     const attesteringData = {
       aktiviter: [
-        {
-          aktivitetId: 6020942,
-          grunnlag: JSON.stringify({
-            oppgittInntekt: 450000,
-            innhentetInntekt: 475000,
-            grunnbelop: 118620,
-          }),
-          vurdering: JSON.stringify({
-            epsInntektOver2G: true,
-          }),
-        },
-        {
-          aktivitetId: 6020943,
-          grunnlag: JSON.stringify({
-            sokersBostedsadresser: [],
-            samboer: {
-              fnr: '12345678901',
-              navn: {
-                fornavn: 'Test',
-                mellomnavn: null,
-                etternavn: 'Testesen',
+        ...(epsAktivitet
+          ? [
+              {
+                aktivitetId: epsAktivitet.aktivitetId,
+                vurdertTidspunkt: '2025-01-15T16:50:00.000000',
+                vurdertAvBrukerId: 'A123456',
+                vurdertAvBrukerNavn: 'Siri Saksbehandler',
+                grunnlag: JSON.stringify({
+                  oppgittInntekt: '450000',
+                  grunnbelop: '118620',
+                  sokerKontaktinfo: {
+                    reservertMotDigitalVarsling: false,
+                    aktivDigitalt: true,
+                  },
+                  epsInformasjon: {
+                    fnr: '98765432100',
+                    fornavn: 'Kari',
+                    etternavn: 'Nordmann',
+                    forkortetNavn: 'Nordmann, Kari',
+                  },
+                  estimertInntektOver2gOgOppgittInntektUnder2g: true,
+                  oppgittInntektUnder2g: true,
+                  estimertInntektOver2g: true,
+                  onsketVirkningsdato: '2025-06-01',
+                  epsType: 'SAMBOER',
+                }),
+                vurdering: JSON.stringify({
+                  epsInntektOver2G: true,
+                }),
               },
-              bostedsadresser: [],
-            },
-            soknad: {
-              datoForSamboerskap: '2023-01-01',
-              harEllerHarHattFellesBarn: true,
-              tidligereEktefelle: false,
-            },
-          }),
-          vurdering: JSON.stringify({
-            samboerFra: '2023-01-01',
-            vurdering: 'SAMBOER_1_5',
-          }),
-        },
+            ]
+          : []),
+        ...(samboerAktivitet
+          ? [
+              {
+                aktivitetId: samboerAktivitet.aktivitetId,
+                vurdertTidspunkt: '2025-01-15T16:51:00.000000',
+                vurdertAvBrukerId: 'A123456',
+                vurdertAvBrukerNavn: 'Siri Saksbehandler',
+                grunnlag: JSON.stringify({
+                  sokersBostedsadresser: [],
+                  samboer: {
+                    fnr: '12345678901',
+                    navn: {
+                      fornavn: 'Test',
+                      mellomnavn: null,
+                      etternavn: 'Testesen',
+                    },
+                    bostedsadresser: [],
+                  },
+                  soknad: {
+                    datoForSamboerskap: '2023-01-01',
+                    harEllerHarHattFellesBarn: true,
+                    tidligereEktefelle: false,
+                  },
+                }),
+                vurdering: JSON.stringify({
+                  samboerFra: '2023-01-01',
+                  vurdering: 'SAMBOER_1_5',
+                }),
+              },
+            ]
+          : []),
       ],
     }
 
@@ -108,7 +147,7 @@ const handlers = [
   http.get(
     '*/api/saksbehandling/alde/behandling/:behandlingId/aktivitet/:aktivitetId/grunnlagsdata',
     ({ params, request }) => {
-      const { behandlingId, aktivitetId } = params
+      const { aktivitetId } = params
       console.log(`🎯 MSW intercepted grunnlagsdata request to: ${request.url}`)
 
       const mockData = loadMockData(`aktivitet/${aktivitetId}-grunnlagsdata.json`)
@@ -126,7 +165,7 @@ const handlers = [
   http.get(
     '*/api/saksbehandling/alde/behandling/:behandlingId/aktivitet/:aktivitetId/vurdering',
     ({ params, request }) => {
-      const { behandlingId, aktivitetId } = params
+      const { aktivitetId } = params
       console.log(`🎯 MSW intercepted vurdering request to: ${request.url}`)
 
       const mockData = loadMockData(`aktivitet/${aktivitetId}-vurdering.json`)
@@ -141,7 +180,29 @@ const handlers = [
     },
   ),
 
-  // You can add more API endpoints here
+  // POST /api/saksbehandling/alde/behandling/:id/aktivitet/:aid/vurdering
+  http.post('*/api/saksbehandling/alde/behandling/:behandlingId/aktivitet/:aktivitetId/vurdering', ({ params }) => {
+    console.log(`🎯 MSW intercepted POST vurdering for aktivitet ${params.aktivitetId}`)
+    return HttpResponse.json({ ok: true })
+  }),
+
+  // POST /api/saksbehandling/alde/behandling/:id/fortsett
+  http.post('*/api/saksbehandling/alde/behandling/:behandlingId/fortsett', ({ params }) => {
+    console.log(`🎯 MSW intercepted POST fortsett for behandling ${params.behandlingId}`)
+    return HttpResponse.json({ ok: true })
+  }),
+
+  // POST /api/saksbehandling/alde/behandling/:id/attester
+  http.post('*/api/saksbehandling/alde/behandling/:behandlingId/attester', ({ params }) => {
+    console.log(`🎯 MSW intercepted POST attester for behandling ${params.behandlingId}`)
+    return HttpResponse.json({ ok: true })
+  }),
+
+  // POST /api/saksbehandling/alde/behandling/:id/returner
+  http.post('*/api/saksbehandling/alde/behandling/:behandlingId/returner', ({ params }) => {
+    console.log(`🎯 MSW intercepted POST returner for behandling ${params.behandlingId}`)
+    return HttpResponse.json({ ok: true })
+  }),
 ]
 
 // Create and export the server

--- a/app/routes/behandling/$behandlingId.module.css
+++ b/app/routes/behandling/$behandlingId.module.css
@@ -1,3 +1,9 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+
 .xsmall {
   :global(.aksel-heading--small) {
     font-size: var(--ax-font-size-heading-xsmall) !important;
@@ -8,15 +14,30 @@
   max-width: 305px;
 }
 
+.pageFullHeight :global(.aksel-page__content--grow) {
+  display: flex;
+  flex-direction: column;
+  padding-block-end: 0;
+}
+
+.pageFullHeight {
+  min-height: 0;
+  flex: 1;
+}
+
+.mainContent {
+  flex: 1;
+  min-width: 0;
+  max-width: var(--ax-breakpoint-xl);
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+}
+
 @media (min-width: 1440px) {
-  .resposiveBorder {
+  .mainContent {
     border-right-width: 1px;
     border-right-color: var(--ax-border-neutral-subtle);
     border-right-style: solid;
-
-    padding-block-end: 8px;
-    padding-block-start: 8px;
-    padding-inline-end: 40px;
-    padding-inline-start: 40px;
   }
 }

--- a/app/routes/behandling/$behandlingId.tsx
+++ b/app/routes/behandling/$behandlingId.tsx
@@ -307,7 +307,7 @@ export default function Behandling({ loaderData }: Route.ComponentProps) {
   }, [activeStepIndex])
 
   return (
-    <div>
+    <div className={behandlingStyles.root}>
       <Header
         me={me}
         isDarkmode={isDarkmode}
@@ -319,7 +319,7 @@ export default function Behandling({ loaderData }: Route.ComponentProps) {
         verdandeBehandlingUrl={verdandeBehandlingUrl}
       />
       <Box.New asChild background={'default'}>
-        <Page>
+        <Page contentBlockPadding="none" className={behandlingStyles.pageFullHeight}>
           <VStack>
             <Box.New
               paddingInline="10"
@@ -450,7 +450,7 @@ export default function Behandling({ loaderData }: Route.ComponentProps) {
             </Box.New>
           )}
 
-          <HStack justify="start" wrap={false}>
+          <HStack justify="start" wrap={false} style={{ flex: 1 }}>
             <Show asChild above="2xl">
               <Box.New
                 borderWidth="0 1 0 0"
@@ -488,11 +488,9 @@ export default function Behandling({ loaderData }: Route.ComponentProps) {
               </Box.New>
             </Show>
 
-            <div className={behandlingStyles.resposiveBorder}>
-              <Page.Block as="main" style={{ maxWidth: 'var(--ax-breakpoint-lg)' }}>
-                {behandlingJobber ? <AldeLoader /> : <Outlet context={{ behandling, avbrytAktivitet }} />}
-              </Page.Block>
-            </div>
+            <main className={behandlingStyles.mainContent}>
+              {behandlingJobber ? <AldeLoader /> : <Outlet context={{ behandling, avbrytAktivitet }} />}
+            </main>
           </HStack>
 
           <Modal ref={ref} header={{ heading: 'Vil du avbryte del-automatisk behandling?' }}>

--- a/app/routes/behandling/$behandlingId.tsx
+++ b/app/routes/behandling/$behandlingId.tsx
@@ -458,13 +458,18 @@ export default function Behandling({ loaderData }: Route.ComponentProps) {
                 className={behandlingStyles.pennyVenstremenyBredde}
               >
                 <VStack>
-                  <Box.New paddingBlock="space-24" paddingInline="space-44">
+                  <Box.New
+                    paddingBlock="space-24"
+                    paddingInline="space-44"
+                    borderWidth="0 0 1 0"
+                    borderColor="neutral-subtle"
+                  >
                     <BodyShort as="h2" size="small" weight="semibold">
                       {behandling.processName}
                     </BodyShort>
                   </Box.New>
 
-                  <Box.New paddingBlock="space-12" paddingInline="space-44">
+                  <Box.New paddingBlock="space-24" paddingInline="space-44">
                     <Process hideStatusText={true}>
                       {allSteps
                         .filter(it => showStepper || it.handlerName)

--- a/app/routes/behandling/$behandlingId/aktivitet/$aktivitetId.tsx
+++ b/app/routes/behandling/$behandlingId/aktivitet/$aktivitetId.tsx
@@ -109,7 +109,7 @@ export default function Aktivitet({ loaderData }: Route.ComponentProps) {
     return <FeilendeBehandling dato={dato} behandling={behandling} retry={retry} avbrytAktivitet={avbrytAktivitet} />
   } else {
     return (
-      <Page.Block gutters className="aktivitet" style={{ paddingTop: '2em' }} width="xl">
+      <Page.Block className="aktivitet">
         <Outlet context={{ behandling, aktivitet, avbrytAktivitet }} />
 
         {!outlet && (

--- a/app/routes/behandling/$behandlingId/attestering/index.tsx
+++ b/app/routes/behandling/$behandlingId/attestering/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef } from 'react'
 import { data, Form, redirect, useOutletContext } from 'react-router'
 import { createBehandlingApi } from '~/api/behandling-api'
 import type { AktivitetAtt } from '~/api/behandling-api/types'
+import commonStyles from '~/common.module.css'
 import type { AktivitetOutletContext } from '~/types/aktivitetOutletContext'
 import { type AktivitetDTO, AldeBehandlingStatus, type BehandlingDTO } from '~/types/behandling'
 import { getAllServerComponents } from '~/utils/component-discovery'
@@ -205,9 +206,9 @@ export default function Attestering({ loaderData, actionData }: Route.ComponentP
   }
 
   return (
-    <Page.Block width="xl">
+    <Page.Block width="xl" gutters className={commonStyles.behandlingPage}>
       <VStack gap="space-28">
-        <Heading level="1" size="large" style={{ paddingTop: '2rem' }}>
+        <Heading level="1" size="large">
           Oppgaven er til attestering
         </Heading>
         <VStack gap="space-56">
@@ -226,7 +227,7 @@ export default function Attestering({ loaderData, actionData }: Route.ComponentP
                 <Box.New
                   borderColor="neutral-subtleA"
                   borderWidth="1 1 0 1"
-                  padding="space-28"
+                  paddingInline="space-28"
                   borderRadius="xlarge xlarge 0 0"
                 >
                   <div className="component-area">

--- a/app/routes/behandling/$behandlingId/attestert-og-iverksatt/index.tsx
+++ b/app/routes/behandling/$behandlingId/attestert-og-iverksatt/index.tsx
@@ -67,10 +67,10 @@ const AttestertOgIverksatt = ({ loaderData }: Route.ComponentProps) => {
           <HStack align="center">Saken er attestert og iverksatt</HStack>
         </Heading>
 
-        <HStack gap="2">
+        <VStack gap="2" align="center">
           <Link href={psakPensjonsoversikt}>Pensjonsoversikt</Link>
           <Link href={psakOppgaveoversikt}>Oppgavelisten</Link>
-        </HStack>
+        </VStack>
       </VStack>
     </Page.Block>
   )

--- a/app/routes/behandling/$behandlingId/avbrutt-automatisk/index.tsx
+++ b/app/routes/behandling/$behandlingId/avbrutt-automatisk/index.tsx
@@ -32,9 +32,9 @@ const AvbruttAutomatisk = ({ loaderData }: Route.ComponentProps) => {
           </Heading>
           <BodyLong>Saksbehandlingen må fortsettes som normal kravbehandling.</BodyLong>
         </VStack>
-        <HStack gap="2" justify="center">
+        <VStack gap="2" align="center">
           <Link href={pensjonsoversiktUrl}>Pensjonsoversikt</Link>
-        </HStack>
+        </VStack>
       </VStack>
     </Page.Block>
   )

--- a/app/routes/behandling/$behandlingId/avbrutt-manuelt/index.tsx
+++ b/app/routes/behandling/$behandlingId/avbrutt-manuelt/index.tsx
@@ -30,9 +30,9 @@ const AvbruttManuelt = ({ loaderData }: Route.ComponentProps) => {
           Del-automatisk behandling er avbrutt
         </Heading>
 
-        <HStack gap="2" justify="center">
+        <VStack gap="2" align="center">
           <Link href={pensjonsoversiktUrl}>Pensjonsoversikt</Link>
-        </HStack>
+        </VStack>
       </VStack>
     </Page.Block>
   )

--- a/app/routes/behandling/$behandlingId/oppsummering/index.tsx
+++ b/app/routes/behandling/$behandlingId/oppsummering/index.tsx
@@ -95,7 +95,7 @@ export default function Attestering({ loaderData }: Route.ComponentProps) {
   }
 
   return (
-    <Page.Block gutters className={commonStyles.page}>
+    <Page.Block gutters className={commonStyles.behandlingPage}>
       <Heading level="1" size="large" spacing>
         Oppsummering av behandlingen
       </Heading>

--- a/app/routes/behandling/$behandlingId/venter-attestering/index.tsx
+++ b/app/routes/behandling/$behandlingId/venter-attestering/index.tsx
@@ -34,10 +34,10 @@ const Avbrutt = ({ loaderData }: Route.ComponentProps) => {
           <HStack align="center">Sendt til attestering</HStack>
         </Heading>
 
-        <HStack gap="2">
+        <VStack align="center" gap="2">
           <Link href={psakPensjonsoversikt}>Pensjonsoversikt</Link>
           <Link href={psakOppgaveoversikt}>Oppgavelisten</Link>
-        </HStack>
+        </VStack>
       </VStack>
     </Page.Block>
   )


### PR DESCRIPTION

- **Layout**: Behandling-siden bruker nå full viewport-høyde med konsistent padding og border. Aktivitet-vurdering-grid har fått fast sidebar-bredde og responsiv gutter.
- **Vertikal lenkevisning**: Grupperte lenker (Pensjonsoversikt, Oppgavelisten) vises nå vertikalt i stedet for horisontalt på alle statussider.
- **Mock-data**: Lagt til flere mock-behandlinger for ulike statuser (FULLFORT, AVBRUTT, VENTER_ATTESTERING), POST-handlere for vurdering/attestering, og en `TESTABLE_ROUTES.md`-oversikt over testbare ruter.