### PR TITLE
chore: tooling, konfig og Copilot-oppsett

### DIFF
--- a/.github/instructions/accessibility.instructions.md
+++ b/.github/instructions/accessibility.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "src/**/*.{tsx,jsx}"
+applyTo: "app/**/*.{tsx,jsx}"
 ---
 
 # Accessibility (UU) Standards

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules/
 
 # Storybook
 /storybook-static/
+
+# Vitest coverage
+/coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,10 +149,10 @@ The system automatically:
 ## Testing Your Implementation
 
 ```sh
-npm test          # Run tests in watch mode
-npm run test:ci   # Run tests once (use this after editing tests or tested files)
-npm run typecheck # Type checking
-npm run dev:mock  # Development with mock API
+pnpm test          # Run tests in watch mode
+pnpm test:ci       # Run tests once (use this after editing tests or tested files)
+pnpm typecheck     # Type checking
+pnpm dev:mock      # Development with mock API
 ```
 
 
@@ -177,7 +177,7 @@ Mock API responses are located in `app/mocks/data/`. Check existing files like `
 
 ### TypeScript errors
 
-- Run `npm run typecheck` to generate React Router types
+- Run `pnpm typecheck` to generate React Router types
 - Import types from `./+types`
 
 ## API Endpoints
@@ -204,8 +204,8 @@ The folder structure IS the configuration. Keep it simple, keep it working!
 
 Before declaring work complete, follow this checklist in order:
 
-1. Run `npm run test:ci` after creating or modifying test files, editing files with associated tests, or making changes to core functionality. If `npm run test:ci` fails to run (e.g., missing dependencies, script not found), do not attempt to fix the toolchain — report the exact error output to the user and ask them to resolve the environment issue before proceeding.
-2. Run `npm run typecheck` to check for TypeScript errors. If it fails to run, report the exact error output to the user.
+1. Run `pnpm test:ci` after creating or modifying test files, editing files with associated tests, or making changes to core functionality. If `pnpm test:ci` fails to run (e.g., missing dependencies, script not found), do not attempt to fix the toolchain — report the exact error output to the user and ask them to resolve the environment issue before proceeding.
+2. Run `pnpm typecheck` to check for TypeScript errors. If it fails to run, report the exact error output to the user.
 3. Check diagnostics for all files you have edited — both implementation files and test files. Fix all type errors and linting issues.
 4. Verify that no plain HTML elements replace available Aksel components.
 5. Confirm all new files are exported from `index.tsx`.
@@ -216,14 +216,14 @@ Prosjektet har støtte for automatisk generering av skjermbilder som brukes i do
 
 ### Hvordan det fungerer
 
-Skjermbildene tas med Playwright mot mock-serveren (`npm run dev:mock`). Scriptet navigerer til behandlingsruter, setter alde-settings-cookie for å vise stepper og metadata, og tar fullside-skjermbilder.
+Skjermbildene tas med Playwright mot mock-serveren (`pnpm dev:mock`). Scriptet navigerer til behandlingsruter, setter alde-settings-cookie for å vise stepper og metadata, og tar fullside-skjermbilder.
 
 ### Kommandoer
 
 ```sh
-npm run dev:mock                 # Start mock-serveren (må kjøre først)
-npm run capture-screenshots      # Ta alle skjermbilder (lagres i screenshots/)
-npm run capture-docs-screenshots # Ta kun docs-skjermbilder og kopier til pensjon-dokumentasjon
+pnpm dev:mock                    # Start mock-serveren (må kjøre først)
+pnpm capture-screenshots         # Ta alle skjermbilder (lagres i screenshots/)
+pnpm capture-docs-screenshots    # Ta kun docs-skjermbilder og kopier til pensjon-dokumentasjon
 ```
 
 ### Legge til nye skjermbilder

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,13 +59,13 @@ app/behandlinger/alderspensjon-soknad/vurder-samboer/
 
 If a folder matching the handler name already exists, inspect its contents before creating any files. If an implementation already exists, report this to the user and ask whether to overwrite, extend, or skip.
 
-### Step 3: Create PascalCase component file
+### Step 3: Create index.tsx with loader, action, and component
 
-Create a PascalCase filename from the handler name (e.g., handler name `vurder-samboer` becomes `VurderSamboer.tsx`). The file should contain a loader, action, and default-exported component following React Router 7 patterns. Unless otherwise specified, implement empty boilerplate for the loader and action.
+Create `index.tsx` directly in the aktivitet folder. This file contains the `loader`, `action`, and default-exported component following React Router 7 patterns — it is the route module itself, not a re-export wrapper. Unless otherwise specified, implement empty boilerplate for the loader and action.
 
-### Step 4: Create index.tsx
+### Step 4: Extract sub-components when useful
 
-Export your component, loader, and action from index.tsx, this will be the import path.
+If the component grows large or has clearly separable parts (e.g. a status-specific view, an address display block), extract them into their own PascalCase files alongside `index.tsx` (e.g. `AfpLivsvarigVenter.tsx`, `AddressBlock/`) and import them into `index.tsx`. This is optional — small aktiviteter can keep everything in `index.tsx`.
 
 ### Step 5: Implement Component
 
@@ -77,7 +77,7 @@ For structural reference (import patterns and component layout), check `app/beha
 
 - ✅ **Use Aksel components** (`@navikt/ds-react`) - This is IMPORTANT
 - ✅ Use exact handler names from API as folder names
-- ✅ Export from index.tsx
+- ✅ Define loader, action, and default component in `index.tsx`
 - ✅ Use React Router 7 patterns (loader, action, default export)
 - ✅ Keep behandling context when fetching data
 
@@ -208,7 +208,7 @@ Before declaring work complete, follow this checklist in order:
 2. Run `pnpm typecheck` to check for TypeScript errors. If it fails to run, report the exact error output to the user.
 3. Check diagnostics for all files you have edited — both implementation files and test files. Fix all type errors and linting issues.
 4. Verify that no plain HTML elements replace available Aksel components.
-5. Confirm all new files are exported from `index.tsx`.
+5. Confirm the loader, action, and default component live in `index.tsx` (any extracted sub-components should be imported there).
 
 ## Automatiske skjermbilder for dokumentasjon
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ An `aktivitet` is a specific task within a behandling. Each aktivitet has:
 
 - `aktivitetId`: Unique identifier
 - `handlerName`: Maps to folder name (e.g., "vurder-samboer")
-- Some aktiviteter are backend-only (no `handlerName`)
+- Some aktiviteter are backend-only (no `handlerName`) — do not create a folder for these; inform the user that this aktivitet is backend-only and requires no UI implementation
 - Some need UI implementation for manual processing
 
 ## YOUR PRIMARY WORK AREA: app/behandlinger/
@@ -49,15 +49,19 @@ Look for handler names in the API response:
 
 ### Step 2: Create Folder Structure
 
+If the behandling-level `handlerName` is absent from the API response, do not create any folders. Inform the user that a behandling `handlerName` is required to determine the correct folder path.
+
 Create folders matching EXACTLY the handler names:
 
 ```sh
 app/behandlinger/alderspensjon-soknad/vurder-samboer/
 ```
 
-### Step 3: Create NameOfActivity.tsx
+If a folder matching the handler name already exists, inspect its contents before creating any files. If an implementation already exists, report this to the user and ask whether to overwrite, extend, or skip.
 
-Create capitalized name of activity and containing loader, action and component (as react-router 7). Just empty boilerplate action and loader if nothing else is specified.
+### Step 3: Create PascalCase component file
+
+Create a PascalCase filename from the handler name (e.g., handler name `vurder-samboer` becomes `VurderSamboer.tsx`). The file should contain a loader, action, and default-exported component following React Router 7 patterns. Unless otherwise specified, implement empty boilerplate for the loader and action.
 
 ### Step 4: Create index.tsx
 
@@ -65,11 +69,7 @@ Export your component, loader, and action from index.tsx, this will be the impor
 
 ### Step 5: Implement Component
 
-Check existing implementations in `app/behandlinger/alderspensjon-soknad/vurder-samboer/` for reference on:
-
-- How to structure a component with loader and action
-- How to use React Router 7 patterns
-- How to fetch data with the behandlingsId parameter
+For structural reference (import patterns and component layout), check `app/behandlinger/alderspensjon-soknad/vurder-samboer/`. Do not infer a full data-fetching implementation from that reference unless the user has asked for it — keep the loader and action as boilerplate unless otherwise specified. If the reference path does not exist in the workspace, fall back to the boilerplate described in Step 3 and notify the user that the reference could not be found.
 
 ## Critical Rules
 
@@ -155,25 +155,6 @@ pnpm typecheck     # Type checking
 pnpm dev:mock      # Development with mock API
 ```
 
-### IMPORTANT: Run Tests After Changes
-
-**ALWAYS run `pnpm test:ci` after:**
-
-- Creating or modifying test files
-- Editing files that have associated tests
-- Making changes to core functionality
-
-This ensures your changes don't break existing tests and that new tests actually run and pass.
-
-### IMPORTANT: Check Diagnostics Before Finishing
-
-**ALWAYS check for TypeScript/linting errors before declaring work complete:**
-
-- Use the diagnostics tool to check files you've edited
-- Fix all red lines and type errors
-- Even if tests pass, diagnostics might reveal issues
-- Don't assume - verify!
-- Check BOTH the implementation file AND test file
 
 ### TypeScript Best Practices
 
@@ -202,7 +183,9 @@ Mock API responses are located in `app/mocks/data/`. Check existing files like `
 ## API Endpoints
 
 - `GET /api/saksbehandling/alde/behandling/{behandlingId}` - Get behandling with aktiviteter
-- `POST /api/saksbehandling/alder/forstegangsbehandling/{behandlingId}/{endpoint}` - Submit aktivitet decisions
+- `POST /api/saksbehandling/alde/behandling/{behandlingId}/aktivitet/{aktivitetId}/vurdering` - Submit aktivitet decisions
+
+Note: Both GET and POST base paths use `/alde/` — this is intentional.
 
 ## Strangler Pattern Context
 
@@ -216,6 +199,16 @@ This app gradually replaces a legacy system. New aktiviteter are migrated increm
 4. **Folder names ARE handler names** - no configuration needed
 
 The folder structure IS the configuration. Keep it simple, keep it working!
+
+## Definition of Done
+
+Before declaring work complete, follow this checklist in order:
+
+1. Run `pnpm test:ci` after creating or modifying test files, editing files with associated tests, or making changes to core functionality. If `pnpm test:ci` fails to run (e.g., missing dependencies, script not found), do not attempt to fix the toolchain — report the exact error output to the user and ask them to resolve the environment issue before proceeding.
+2. Run `pnpm typecheck` to check for TypeScript errors. If it fails to run, report the exact error output to the user.
+3. Check diagnostics for all files you have edited — both implementation files and test files. Fix all type errors and linting issues.
+4. Verify that no plain HTML elements replace available Aksel components.
+5. Confirm all new files are exported from `index.tsx`.
 
 ## Automatiske skjermbilder for dokumentasjon
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,10 +149,10 @@ The system automatically:
 ## Testing Your Implementation
 
 ```sh
-pnpm test          # Run tests in watch mode
-pnpm test:ci       # Run tests once (use this after editing tests or tested files)
-pnpm typecheck     # Type checking
-pnpm dev:mock      # Development with mock API
+npm test          # Run tests in watch mode
+npm run test:ci   # Run tests once (use this after editing tests or tested files)
+npm run typecheck # Type checking
+npm run dev:mock  # Development with mock API
 ```
 
 
@@ -177,7 +177,7 @@ Mock API responses are located in `app/mocks/data/`. Check existing files like `
 
 ### TypeScript errors
 
-- Run `pnpm typecheck` to generate React Router types
+- Run `npm run typecheck` to generate React Router types
 - Import types from `./+types`
 
 ## API Endpoints
@@ -204,8 +204,8 @@ The folder structure IS the configuration. Keep it simple, keep it working!
 
 Before declaring work complete, follow this checklist in order:
 
-1. Run `pnpm test:ci` after creating or modifying test files, editing files with associated tests, or making changes to core functionality. If `pnpm test:ci` fails to run (e.g., missing dependencies, script not found), do not attempt to fix the toolchain — report the exact error output to the user and ask them to resolve the environment issue before proceeding.
-2. Run `pnpm typecheck` to check for TypeScript errors. If it fails to run, report the exact error output to the user.
+1. Run `npm run test:ci` after creating or modifying test files, editing files with associated tests, or making changes to core functionality. If `npm run test:ci` fails to run (e.g., missing dependencies, script not found), do not attempt to fix the toolchain — report the exact error output to the user and ask them to resolve the environment issue before proceeding.
+2. Run `npm run typecheck` to check for TypeScript errors. If it fails to run, report the exact error output to the user.
 3. Check diagnostics for all files you have edited — both implementation files and test files. Fix all type errors and linting issues.
 4. Verify that no plain HTML elements replace available Aksel components.
 5. Confirm all new files are exported from `index.tsx`.
@@ -216,14 +216,14 @@ Prosjektet har støtte for automatisk generering av skjermbilder som brukes i do
 
 ### Hvordan det fungerer
 
-Skjermbildene tas med Playwright mot mock-serveren (`pnpm dev:mock`). Scriptet navigerer til behandlingsruter, setter alde-settings-cookie for å vise stepper og metadata, og tar fullside-skjermbilder.
+Skjermbildene tas med Playwright mot mock-serveren (`npm run dev:mock`). Scriptet navigerer til behandlingsruter, setter alde-settings-cookie for å vise stepper og metadata, og tar fullside-skjermbilder.
 
 ### Kommandoer
 
 ```sh
-pnpm dev:mock                    # Start mock-serveren (må kjøre først)
-pnpm capture-screenshots         # Ta alle skjermbilder (lagres i screenshots/)
-pnpm capture-docs-screenshots    # Ta kun docs-skjermbilder og kopier til pensjon-dokumentasjon
+npm run dev:mock                 # Start mock-serveren (må kjøre først)
+npm run capture-screenshots      # Ta alle skjermbilder (lagres i screenshots/)
+npm run capture-docs-screenshots # Ta kun docs-skjermbilder og kopier til pensjon-dokumentasjon
 ```
 
 ### Legge til nye skjermbilder

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Med mock-data:
 pnpm dev:mock
 ```
 
-Applikasjonen kjører på `http://localhost:5173`
+Applikasjonen kjører på `http://localhost:3001`
 
 ### Testing
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "4.1.9",
     "glob": "^13.0.6",
     "lefthook": "^2.1.9",
     "msw": "^2.14.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 8.1.0(@react-router/serve@8.1.0(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3))(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
       '@storybook/addon-vitest':
         specifier: ^10.4.6
-        version: 10.4.6(@vitest/runner@4.1.9)(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.3)(react@19.2.7))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))
+        version: 10.4.6(@vitest/runner@4.1.9)(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.3)(react@19.2.7))(vitest@4.1.9)
       '@storybook/react':
         specifier: ^10.4.6
         version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.3)(react@19.2.7))(typescript@6.0.3)
@@ -111,6 +111,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@vitest/coverage-v8':
+        specifier: 4.1.9
+        version: 4.1.9(vitest@4.1.9)
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -143,7 +146,7 @@ importers:
         version: 6.0.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
 packages:
 
@@ -282,6 +285,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.5.1':
     resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
@@ -1705,6 +1712,15 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
+  '@vitest/coverage-v8@4.1.9':
+    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.9
+      vitest: 4.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -1796,6 +1812,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -2264,6 +2283,10 @@ packages:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2274,6 +2297,9 @@ packages:
 
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -2345,9 +2371,24 @@ packages:
     resolution: {integrity: sha512-PGEHtwMnKbZpeSEXW2Utx+/JWed7dp6DiH0WWg33vGSDA7RUvpUeJSVlLrVkQ1RCpvDOUc/eH9ql7VsdbBZ8pA==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2520,6 +2561,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-fetch-happen@15.0.6:
     resolution: {integrity: sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==}
@@ -3049,6 +3097,10 @@ packages:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -3522,6 +3574,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.5.1':
     optionalDependencies:
@@ -4417,14 +4471,14 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-vitest@10.4.6(@vitest/runner@4.1.9)(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.3)(react@19.2.7))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))':
+  '@storybook/addon-vitest@10.4.6(@vitest/runner@4.1.9)(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.3)(react@19.2.7))(vitest@4.1.9)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.1.0(react@19.2.7)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.3)(react@19.2.7)
     optionalDependencies:
       '@vitest/runner': 4.1.9
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
     transitivePeerDependencies:
       - react
 
@@ -4779,6 +4833,20 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.9
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -4883,6 +4951,12 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -5336,6 +5410,8 @@ snapshots:
 
   graphql@16.14.2: {}
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.4:
@@ -5346,6 +5422,8 @@ snapshots:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.1
+
+  html-escaper@2.0.2: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -5412,7 +5490,22 @@ snapshots:
 
   isbot@5.1.44: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5538,6 +5631,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   make-fetch-happen@15.0.6:
     dependencies:
@@ -6181,6 +6284,10 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tabbable@6.5.0: {}
@@ -6331,7 +6438,7 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.22.4
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
@@ -6356,6 +6463,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.0.1
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
     transitivePeerDependencies:
       - msw
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,12 @@ export default mergeConfig(
   defineConfig({
     test: {
       setupFiles: ['./app/test/setup-env.ts'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'html'],
+        include: ['app/**/*.{ts,tsx}'],
+        exclude: ['app/**/*.test.{ts,tsx}', 'app/**/*.stories.tsx', 'app/mocks/**', 'app/**/+types/**'],
+      },
     },
   }),
 )

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default mergeConfig(
         provider: 'v8',
         reporter: ['text', 'html'],
         include: ['app/**/*.{ts,tsx}'],
-        exclude: ['app/**/*.test.{ts,tsx}', 'app/**/*.stories.tsx', 'app/mocks/**', 'app/**/+types/**'],
+        exclude: ['app/**/*.test.{ts,tsx}', 'app/**/*.stories.tsx', 'app/mocks/**', 'app/test/**', 'app/**/+types/**'],
       },
     },
   }),


### PR DESCRIPTION
## Hva

Samler verktøy- og konfigurasjonsendringer som ikke er relatert til noen feature.

## Endringer

Etter at `main` fikk pnpm/lefthook/CODEOWNERS/biome 2.5-migreringen (#153–#158) er de fleste av de opprinnelige endringene her allerede en del av `main`. Gjenstående, unike endringer i denne branchen:

- **AGENTS.md:** omstrukturert "Definition of Done"-seksjon (samler tidligere spredte "Run tests"/"Check diagnostics"-påminnelser)
- **`.github/instructions/accessibility.instructions.md`:** rettet feil `applyTo`-sti (`src/**/*` → `app/**/*`, repoet har ingen `src/`-mappe)
- **README.md:** portendring (5173 → 3001, matcher `vite.config.ts`)
- **vitest.config.ts:** lagt til coverage-konfigurasjon (provider `v8`)

## Avhengigheter

Ingen — kan merges uavhengig.
