### PR TITLE
feat: PSAK-URL med PID-kryptering

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,6 +5,7 @@ AZURE_OPENID_CONFIG_TOKEN_ENDPOINT=https://example.com/token
 PEN_SCOPE=ci
 PEN_URL=https://example.com/pen
 PSAK_SAK_URL_TEMPLATE=https://example.com/psak/sak/{sakId}
+PSAK_OVERSIKT_URL_TEMPLATE=https://example.com/pensjonsoversikt/person/{pid}
 PSAK_OPPGAVEOVERSIKT=https://example.com/psak/oppgaveoversikt
 VERDANDE_BEHANDLING_URL=https://example.com/verdande/behandling/{behandlingId}
 VERDANDE_AKTIVITET_URL=https://example.com/verdande/behandling/{behandlingId}/aktivitet/{aktivitetId}

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -15,6 +15,7 @@ spec:
         - host: "teampensjon-unleash-api.nav.cloud.nais.io"
   envFrom:
     - secret: alde-unleash-api-token
+    - secret: psak-pid-encryption-key
 
   azure:
     application:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -41,6 +41,8 @@ spec:
       value: "{{{ pen.url }}}"
     - name: PSAK_SAK_URL_TEMPLATE
       value: "{{ psak.sak_url_template }}"
+    - name: PSAK_OVERSIKT_URL_TEMPLATE
+      value: "{{ psak.oversikt_url_template }}"
     - name: "PSAK_OPPGAVEOVERSIKT"
       value: "{{ psak.oppgaveoversikt }}"
     - name: "VERDANDE_AKTIVITET_URL"

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -15,6 +15,7 @@ pen:
 
 psak:
   sak_url_template: 'https://pensjon-penny.intern.nav.no/pensjonsoversikt?sakId={sakId}'
+  oversikt_url_template: 'https://pensjon-penny.intern.nav.no/pensjonsoversikt/person/{pid}'
   oppgaveoversikt: 'https://pensjon-psak.nais.adeo.no/psak/springapi/redirect/oppgave/oppgaveliste'
 
 verdande:

--- a/.nais/vars-q2.yaml
+++ b/.nais/vars-q2.yaml
@@ -16,6 +16,7 @@ pen:
 
 psak:
   sak_url_template: 'https://pensjon-penny-q2.{subdomain}.dev.nav.no/pensjonsoversikt?sakId={sakId}'
+  oversikt_url_template: 'https://pensjon-penny-q2.{subdomain}.dev.nav.no/pensjonsoversikt/person/{pid}'
   oppgaveoversikt: 'https://pensjon-psak-q2.{subdomain}.dev.nav.no/psak/springapi/redirect/oppgave/oppgaveliste'
 
 verdande:

--- a/app/auth/auth.server.ts
+++ b/app/auth/auth.server.ts
@@ -39,7 +39,7 @@ if (isLocalEnv) {
   })
 
   returnToCookie = createCookie('return-to', {
-    path: '/',
+    path: '/auth',
     httpOnly: true,
     sameSite: 'lax',
     maxAge: 300,
@@ -58,6 +58,12 @@ if (isLocalEnv) {
         redirectURI: azureCallbackUrl,
 
         scopes: ['openid', 'offline_access', `api://${env.clientId}/.default`],
+        cookie: {
+          name: 'alde-oauth2',
+          path: '/auth',
+          httpOnly: true,
+          sameSite: 'Lax',
+        },
       },
       async ({ tokens }) => {
         return {

--- a/app/middleware/user-middleware.ts
+++ b/app/middleware/user-middleware.ts
@@ -1,7 +1,7 @@
 import type { MiddlewareFunction } from 'react-router'
 import { requireAccessToken } from '~/auth/auth.server'
 import { type UserContext, userContext } from '~/context/user-context'
-import { env } from '~/utils/env.server'
+import { env, isMockEnv } from '~/utils/env.server'
 
 export const userMiddleware: MiddlewareFunction = async ({ request, context }) => {
   const url = new URL(request.url)
@@ -10,7 +10,7 @@ export const userMiddleware: MiddlewareFunction = async ({ request, context }) =
   }
 
   // I mock-modus bruker vi mock-data uten autentisering
-  if (process.env.NODE_ENV === 'mock') {
+  if (isMockEnv) {
     context.set(userContext, {
       navident: 'Z990000',
       fornavn: 'Mock',
@@ -30,6 +30,10 @@ export const userMiddleware: MiddlewareFunction = async ({ request, context }) =
       'Content-Type': 'application/json',
     },
   })
+
+  if (!meResponse.ok) {
+    throw new Error(`Kunne ikke hente brukerinfo fra /me (${meResponse.status})`)
+  }
 
   const me: UserContext = await meResponse.json()
   context.set(userContext, me)

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -46,7 +46,6 @@ export const env = loadEnv({
   unleashUrl: 'UNLEASH_SERVER_API_URL',
   unleashApiToken: 'UNLEASH_SERVER_API_TOKEN',
   unleashEnvironment: 'UNLEASH_SERVER_API_ENV',
-}, {
   pidEncryptionKey: 'PSAK_PID_ENCRYPTION_KEY',
 })
 

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -36,6 +36,7 @@ export const env = loadEnv({
   penUrl: 'PEN_URL',
 
   psakSakUrlTemplate: 'PSAK_SAK_URL_TEMPLATE',
+  psakOversiktUrlTemplate: 'PSAK_OVERSIKT_URL_TEMPLATE',
   psakOppgaveoversikt: 'PSAK_OPPGAVEOVERSIKT',
 
   verdandeBehandlingUrl: 'VERDANDE_BEHANDLING_URL',
@@ -45,7 +46,10 @@ export const env = loadEnv({
   unleashUrl: 'UNLEASH_SERVER_API_URL',
   unleashApiToken: 'UNLEASH_SERVER_API_TOKEN',
   unleashEnvironment: 'UNLEASH_SERVER_API_ENV',
+}, {
+  pidEncryptionKey: 'PSAK_PID_ENCRYPTION_KEY',
 })
 
 export const isLocalEnv = process.env.IS_LOCAL_ENV === 'true'
+export const isMockEnv = process.env.NODE_ENV === 'mock' && !process.env.NAIS_CLUSTER_NAME
 export const isVerdandeLinksEnabled = process.env.VERDANDE_LINKS_ENABLED === 'true'

--- a/app/utils/pid-encryption.server.test.ts
+++ b/app/utils/pid-encryption.server.test.ts
@@ -1,0 +1,60 @@
+import { createDecipheriv } from 'node:crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const TEST_KEY = 'MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE'
+
+vi.mock('./env.server', () => ({
+  env: { pidEncryptionKey: TEST_KEY },
+}))
+
+function decryptForTest(encryptedPid: string, key: string): string {
+  const [ivPart, dataPart] = encryptedPid.split('.')
+  const keyBuffer = Buffer.from(key, 'base64url')
+  const iv = Buffer.from(ivPart, 'base64url')
+  const encryptedData = Buffer.from(dataPart, 'base64url')
+
+  const authTag = encryptedData.subarray(encryptedData.length - 12)
+  const ciphertext = encryptedData.subarray(0, encryptedData.length - 12)
+
+  const decipher = createDecipheriv('aes-256-gcm', keyBuffer, iv, { authTagLength: 12 })
+  decipher.setAuthTag(authTag)
+
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf-8')
+}
+
+describe('encryptPid', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('krypterer fødselsnummer til et format med iv og data separert med punktum', async () => {
+    const { encryptPid } = await import('./pid-encryption.server')
+    const encrypted = encryptPid('12345678901')
+    const parts = encrypted.split('.')
+
+    expect(parts).toHaveLength(2)
+    expect(parts[0].length).toBeGreaterThan(0)
+    expect(parts[1].length).toBeGreaterThan(0)
+  })
+
+  it('produserer ulik kryptert verdi for hvert kall fordi IV er tilfeldig', async () => {
+    const { encryptPid } = await import('./pid-encryption.server')
+    const fnr = '12345678901'
+
+    expect(encryptPid(fnr)).not.toBe(encryptPid(fnr))
+  })
+
+  it('krypterer slik at verdien kan dekrypteres tilbake til opprinnelig fødselsnummer', async () => {
+    const { encryptPid } = await import('./pid-encryption.server')
+    const fnr = '12345678901'
+
+    expect(decryptForTest(encryptPid(fnr), TEST_KEY)).toBe(fnr)
+  })
+
+  it('kaster feil når krypteringsnøkkel mangler', async () => {
+    vi.doMock('./env.server', () => ({ env: { pidEncryptionKey: undefined } }))
+    const { encryptPid } = await import('./pid-encryption.server')
+
+    expect(() => encryptPid('12345678901')).toThrow('PSAK_PID_ENCRYPTION_KEY')
+  })
+})

--- a/app/utils/pid-encryption.server.ts
+++ b/app/utils/pid-encryption.server.ts
@@ -1,0 +1,33 @@
+import { createCipheriv, randomBytes } from 'node:crypto'
+import { env } from './env.server'
+
+const PID_ALGORITHM = 'aes-256-gcm'
+const PID_IV_LENGTH = 12
+const PID_AUTH_TAG_LENGTH = 12
+
+function getPidEncryptionKey(): Buffer {
+  if (!env.pidEncryptionKey) {
+    throw new Error('Miljøvariabel PSAK_PID_ENCRYPTION_KEY er ikke satt')
+  }
+
+  const key = Buffer.from(env.pidEncryptionKey, 'base64url')
+  if (key.length !== 32) {
+    throw new Error(`PSAK_PID_ENCRYPTION_KEY må dekode til 32 byte (aes-256-gcm), men var ${key.length} byte`)
+  }
+
+  return key
+}
+
+export function encryptPid(pid: string): string {
+  const key = getPidEncryptionKey()
+  const iv = randomBytes(PID_IV_LENGTH)
+
+  const cipher = createCipheriv(PID_ALGORITHM, key, iv, { authTagLength: PID_AUTH_TAG_LENGTH })
+  const encrypted = Buffer.concat([cipher.update(pid, 'utf-8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+
+  const ivEncoded = iv.toString('base64url')
+  const dataEncoded = Buffer.concat([encrypted, authTag]).toString('base64url')
+
+  return `${ivEncoded}.${dataEncoded}`
+}

--- a/app/utils/psak-oversikt-url.server.test.ts
+++ b/app/utils/psak-oversikt-url.server.test.ts
@@ -5,7 +5,7 @@ const TEST_KEY = 'MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE'
 vi.mock('./env.server', () => ({
   env: {
     psakSakUrlTemplate: 'https://example.com/psak/sak/{sakId}',
-    psakOversiktUrlTemplate: 'https://example.com/pensjonsoversikt/person',
+    psakOversiktUrlTemplate: 'https://example.com/pensjonsoversikt/person/{pid}',
     pidEncryptionKey: TEST_KEY,
   },
 }))

--- a/app/utils/psak-oversikt-url.server.test.ts
+++ b/app/utils/psak-oversikt-url.server.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const TEST_KEY = 'MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE'
+
+vi.mock('./env.server', () => ({
+  env: {
+    psakSakUrlTemplate: 'https://example.com/psak/sak/{sakId}',
+    psakOversiktUrlTemplate: 'https://example.com/pensjonsoversikt/person',
+    pidEncryptionKey: TEST_KEY,
+  },
+}))
+
+describe('buildPsakOversiktUrl', () => {
+  const request = new Request('https://app.intern.nav.no/path')
+
+  it('bruker sakId som query/path-parameter når behandlingen har en sak', async () => {
+    const { buildPsakOversiktUrl } = await import('./psak-oversikt-url.server')
+
+    const url = buildPsakOversiktUrl(request, { sakId: 12345, fnr: null })
+
+    expect(url).toBe('https://example.com/psak/sak/12345')
+  })
+
+  it('bruker kryptert pid som eget path-segment når behandlingen mangler sakId', async () => {
+    const { buildPsakOversiktUrl } = await import('./psak-oversikt-url.server')
+
+    const url = buildPsakOversiktUrl(request, { sakId: null, fnr: '12345678901' })
+
+    expect(url).toMatch(/^https:\/\/example\.com\/pensjonsoversikt\/person\/[\w-]+\.[\w-]+$/)
+  })
+
+  it('faller tilbake til oversikts-URL-en uten pid-segment når verken sakId eller fnr finnes', async () => {
+    const { buildPsakOversiktUrl } = await import('./psak-oversikt-url.server')
+
+    const url = buildPsakOversiktUrl(request, { sakId: null, fnr: null })
+
+    expect(url).toBe('https://example.com/pensjonsoversikt/person')
+  })
+})

--- a/app/utils/psak-oversikt-url.server.ts
+++ b/app/utils/psak-oversikt-url.server.ts
@@ -1,0 +1,18 @@
+import { buildUrl } from './build-url'
+import { env } from './env.server'
+import { encryptPid } from './pid-encryption.server'
+
+export function buildPsakOversiktUrl(
+  request: Request,
+  behandling: { sakId: number | null; fnr: string | null },
+): string {
+  if (behandling.sakId) {
+    return buildUrl(env.psakSakUrlTemplate, request, { sakId: behandling.sakId })
+  }
+
+  if (!behandling.fnr) {
+    return buildUrl(env.psakOversiktUrlTemplate, request, {})
+  }
+
+  return buildUrl(`${env.psakOversiktUrlTemplate}/${encryptPid(behandling.fnr)}`, request, {})
+}

--- a/app/utils/psak-oversikt-url.server.ts
+++ b/app/utils/psak-oversikt-url.server.ts
@@ -6,7 +6,7 @@ export function buildPsakOversiktUrl(
   request: Request,
   behandling: { sakId: number | null; fnr: string | null },
 ): string {
-  if (behandling.sakId) {
+  if (behandling.sakId !== null) {
     return buildUrl(env.psakSakUrlTemplate, request, { sakId: behandling.sakId })
   }
 

--- a/app/utils/psak-oversikt-url.server.ts
+++ b/app/utils/psak-oversikt-url.server.ts
@@ -11,8 +11,8 @@ export function buildPsakOversiktUrl(
   }
 
   if (!behandling.fnr) {
-    return buildUrl(env.psakOversiktUrlTemplate, request, {})
+    return buildUrl(env.psakOversiktUrlTemplate.replace('/{pid}', ''), request, {})
   }
 
-  return buildUrl(`${env.psakOversiktUrlTemplate}/${encryptPid(behandling.fnr)}`, request, {})
+  return buildUrl(env.psakOversiktUrlTemplate, request, { pid: encryptPid(behandling.fnr) })
 }

--- a/fetch-secrets.sh
+++ b/fetch-secrets.sh
@@ -99,6 +99,7 @@ fetch_kubernetes_secrets "AzureAD" "dev-gcp" "pensjon-saksbehandling" "azure-pen
   echo PEN_SCOPE="'api://dev-fss.pensjon-q2.pensjon-pen-q2/.default'"
   echo PEN_URL="'http://localhost:8089'"
   echo PSAK_SAK_URL_TEMPLATE='http://localhost:9080/psak/sak/sakId={sakId}'
+  echo PSAK_OVERSIKT_URL_TEMPLATE='http://localhost:9080/pensjonsoversikt/person/{pid}'
   echo PSAK_OPPGAVEOVERSIKT='http://localhost:9080/psak/springapi/redirect/oppgave/oppgaveliste'
   echo MODIA_PERSONOVERSIKT='https://modiapersonoversikt.ansatt.dev.nav.no/person/{fnr}'
   echo VERDANDE_BEHANDLING_URL="'http://localhost:3000/behandling/{behandlingId}'"
@@ -115,7 +116,9 @@ fetch_kubernetes_secrets "Unleash" "dev-gcp" "pensjon-saksbehandling" "alde-unle
     "UNLEASH_SERVER_API_ENV"
 >> ${envfile}
 
-
+fetch_kubernetes_secrets "PidEncryptionKey" "dev-gcp" "pensjon-q2" "psak-pid-encryption-key" "strict" \
+    "PSAK_PID_ENCRYPTION_KEY"
+>> ${envfile}
 
 
 echo "${bold}Hentet hemmeligheter og oppdatert .env fil ${normal}"


### PR DESCRIPTION
## Hva
Legger til PSAK-URL-builder med PID-kryptering, samt auth-cookie-forbedringer.

## Endringer
- `psak-oversikt-url.server.ts`: bygger PSAK pensjonsoversikt-URL med kryptert PID
- `pid-encryption.server.ts`: krypterer PID med hemmelighet fra Nais
- `auth.server.ts`: fikser cookie-path (`/` → `/auth`) og OAuth2-konfig
- `user-middleware.ts`: oppdaterer middleware
- `.nais/nais.yaml`: psak-pid-encryption-key secret lagt til
- `.env.test`: ny testverdi for PSAK_OVERSIKT_URL_TEMPLATE
- Tester for begge utilities

## Avhengigheter
Ingen — kan merges uavhengig. Bør merges **før** refactor/delte-komponenter-og-hooks (som bruker buildPsakOversiktUrl).