### PR TITLE
refactor: dato-utilities

### DIFF
--- a/app/utils/date/formatDateToAge.test.ts
+++ b/app/utils/date/formatDateToAge.test.ts
@@ -41,6 +41,11 @@ describe('formatDateToAge', () => {
     expect(formatDateToAge(new Date('2023-09-15T12:00:00Z'))).toBe('0 dager')
   })
 
+  it('treats 0 as a valid epoch date (1970-01-01), not as a missing value', () => {
+    expect(formatDateToAge(0)).toBe('53 år')
+    expect(formatDateToAge('0')).toBe('53 år')
+  })
+
   it('returns empty string for invalid date', () => {
     expect(formatDateToAge('not-a-date')).toBe('')
     expect(formatDateToAge('')).toBe('')

--- a/app/utils/date/formatDateToAge.ts
+++ b/app/utils/date/formatDateToAge.ts
@@ -1,4 +1,5 @@
-import { differenceInDays, differenceInMonths, differenceInYears, isValid, parseISO } from 'date-fns'
+import { differenceInDays, differenceInMonths, differenceInYears } from 'date-fns'
+import { parseDate } from './parseDate'
 
 /**
  * Formats a date string or Date object to a human-readable age string (time since).
@@ -8,27 +9,8 @@ import { differenceInDays, differenceInMonths, differenceInYears, isValid, parse
  * @returns A string representation of the age (e.g. "2 years", "3 months", "5 days") or empty string if invalid
  */
 export function formatDateToAge(date: string | Date | number | null | undefined): string {
-  if (!date) return ''
-
-  let dateObj: Date
-
-  if (typeof date === 'string') {
-    // Try to parse as ISO string
-    dateObj = parseISO(date)
-    if (!isValid(dateObj)) {
-      // Fallback: try to parse as timestamp string
-      const timestamp = Number(date)
-      if (!Number.isNaN(timestamp)) {
-        dateObj = new Date(timestamp)
-      }
-    }
-  } else if (typeof date === 'number') {
-    dateObj = new Date(date)
-  } else {
-    dateObj = date
-  }
-
-  if (!isValid(dateObj)) return ''
+  const dateObj = parseDate(date)
+  if (!dateObj) return ''
 
   const now = new Date()
   const years = differenceInYears(now, dateObj)

--- a/app/utils/date/formatDateToNorwegian.test.ts
+++ b/app/utils/date/formatDateToNorwegian.test.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns'
 import { describe, expect, it } from 'vitest'
 import { formatDateToNorwegian } from './formatDateToNorwegian'
 
@@ -24,6 +25,14 @@ describe('formatDateToNorwegian', () => {
     expect(formatDateToNorwegian(null)).toBe('')
     expect(formatDateToNorwegian(undefined)).toBe('')
     expect(formatDateToNorwegian(NaN)).toBe('')
+  })
+
+  it('formaterer epoch (0) som en gyldig dato, ikke som tom verdi', () => {
+    // parseDate() behandler 0 som gyldig (Unix epoch), så formatDateToNorwegian(0)
+    // skal returnere en formatert dato og ikke ''. Dokumenterer bevisst
+    // atferdsendring fra tidligere `if (!date) return ''`-sjekk.
+    expect(formatDateToNorwegian(0)).not.toBe('')
+    expect(formatDateToNorwegian(0)).toBe(format(new Date(0), 'dd.MM.yyyy'))
   })
 
   it('handles timestamp string', () => {

--- a/app/utils/date/formatDateToNorwegian.ts
+++ b/app/utils/date/formatDateToNorwegian.ts
@@ -1,4 +1,5 @@
-import { format, isValid, parseISO } from 'date-fns'
+import { format } from 'date-fns'
+import { parseDate } from './parseDate'
 
 /**
  * Formats a date string or Date object to Norwegian date format "dd.MM.yyyy".
@@ -14,27 +15,8 @@ export function formatDateToNorwegian(
   date: string | Date | number | null | undefined,
   options?: { showTime?: boolean; onlyTimeIfSameDate?: boolean },
 ): string {
-  if (!date) return ''
-
-  let dateObj: Date
-
-  if (typeof date === 'string') {
-    // Try to parse as ISO string
-    dateObj = parseISO(date)
-    if (!isValid(dateObj)) {
-      // Fallback: try to parse as timestamp string
-      const timestamp = Number(date)
-      if (!Number.isNaN(timestamp)) {
-        dateObj = new Date(timestamp)
-      }
-    }
-  } else if (typeof date === 'number') {
-    dateObj = new Date(date)
-  } else {
-    dateObj = date
-  }
-
-  if (!isValid(dateObj)) return ''
+  const dateObj = parseDate(date)
+  if (!dateObj) return ''
 
   const isSameDay = format(dateObj, 'dd.MM.yyyy') === format(new Date(), 'dd.MM.yyyy')
   if (options?.onlyTimeIfSameDate && isSameDay) {

--- a/app/utils/date/index.ts
+++ b/app/utils/date/index.ts
@@ -1,3 +1,4 @@
 export { formatDateToAge } from './formatDateToAge'
 export { formatDateToNorwegian } from './formatDateToNorwegian'
+export { parseDate } from './parseDate'
 export { toMonthAndYear } from './toMonthAndYear'

--- a/app/utils/date/parseDate.test.ts
+++ b/app/utils/date/parseDate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { parseDate } from './parseDate'
+
+describe('parseDate', () => {
+  it('returnerer null for tomme verdier', () => {
+    expect(parseDate(null)).toBeNull()
+    expect(parseDate(undefined)).toBeNull()
+    expect(parseDate('')).toBeNull()
+  })
+
+  it('parser ISO-datostreng', () => {
+    const result = parseDate('2026-07-14')
+    expect(result).toBeInstanceOf(Date)
+    expect(result?.getFullYear()).toBe(2026)
+  })
+
+  it('parser ISO-dato-tid-streng', () => {
+    const result = parseDate('2026-07-14T10:30:00Z')
+    expect(result?.toISOString()).toBe('2026-07-14T10:30:00.000Z')
+  })
+
+  it('parser timestamp gitt som streng', () => {
+    const ts = Date.UTC(2026, 6, 14)
+    expect(parseDate(String(ts))?.getTime()).toBe(ts)
+  })
+
+  it('parser timestamp gitt som tall', () => {
+    const ts = Date.UTC(2026, 6, 14)
+    expect(parseDate(ts)?.getTime()).toBe(ts)
+  })
+
+  it('returnerer det samme Date-objektet for en gyldig Date', () => {
+    const date = new Date('2026-07-14T00:00:00Z')
+    expect(parseDate(date)).toBe(date)
+  })
+
+  it('returnerer null for ugyldig datostreng', () => {
+    expect(parseDate('ikke-en-dato')).toBeNull()
+  })
+
+  it('returnerer null for ugyldig Date', () => {
+    expect(parseDate(new Date('invalid'))).toBeNull()
+  })
+})

--- a/app/utils/date/parseDate.test.ts
+++ b/app/utils/date/parseDate.test.ts
@@ -34,6 +34,11 @@ describe('parseDate', () => {
     expect(parseDate('0')?.getTime()).toBe(0)
   })
 
+  it('returnerer null for whitespace-streng i stedet for å tolke den som epoch (0)', () => {
+    expect(parseDate('   ')).toBeNull()
+    expect(parseDate('\t\n')).toBeNull()
+  })
+
   it('returnerer det samme Date-objektet for en gyldig Date', () => {
     const date = new Date('2026-07-14T00:00:00Z')
     expect(parseDate(date)).toBe(date)

--- a/app/utils/date/parseDate.test.ts
+++ b/app/utils/date/parseDate.test.ts
@@ -29,6 +29,11 @@ describe('parseDate', () => {
     expect(parseDate(ts)?.getTime()).toBe(ts)
   })
 
+  it('parser epoch (0) som gyldig timestamp, ikke som tom verdi', () => {
+    expect(parseDate(0)?.getTime()).toBe(0)
+    expect(parseDate('0')?.getTime()).toBe(0)
+  })
+
   it('returnerer det samme Date-objektet for en gyldig Date', () => {
     const date = new Date('2026-07-14T00:00:00Z')
     expect(parseDate(date)).toBe(date)

--- a/app/utils/date/parseDate.test.ts
+++ b/app/utils/date/parseDate.test.ts
@@ -39,6 +39,11 @@ describe('parseDate', () => {
     expect(parseDate('\t\n')).toBeNull()
   })
 
+  it('parser en gyldig ISO-streng med omkringliggende whitespace', () => {
+    const ts = Date.UTC(2026, 6, 14)
+    expect(parseDate('  2026-07-14T00:00:00.000Z  ')?.getTime()).toBe(ts)
+  })
+
   it('returnerer det samme Date-objektet for en gyldig Date', () => {
     const date = new Date('2026-07-14T00:00:00Z')
     expect(parseDate(date)).toBe(date)

--- a/app/utils/date/parseDate.ts
+++ b/app/utils/date/parseDate.ts
@@ -1,5 +1,19 @@
 import { isValid, parseISO } from 'date-fns'
 
+/**
+ * Parser en dato fra ulike inputformater til et Date-objekt.
+ *
+ * Aksepterer ISO-datostrenger, numeriske timestamps (millisekunder,
+ * samme semantikk som `new Date(ms)`), Date-objekter, eller
+ * numeriske strenger (f.eks. "1735689600000").
+ *
+ * `0` og `"0"` tolkes som gyldig input (Unix epoch, 1970-01-01), ikke
+ * som en tom verdi. `null`, `undefined`, tom streng og whitespace-only
+ * strenger returnerer `null`.
+ *
+ * @param date - Datoen som skal parses
+ * @returns Et gyldig Date-objekt, eller `null` hvis input mangler eller ikke kan parses
+ */
 export function parseDate(date: string | Date | number | null | undefined): Date | null {
   if (date === null || date === undefined) return null
   if (typeof date === 'string' && date.trim() === '') return null

--- a/app/utils/date/parseDate.ts
+++ b/app/utils/date/parseDate.ts
@@ -1,14 +1,15 @@
 import { isValid, parseISO } from 'date-fns'
 
 export function parseDate(date: string | Date | number | null | undefined): Date | null {
-  if (date === null || date === undefined || date === '') return null
+  if (date === null || date === undefined) return null
+  if (typeof date === 'string' && date.trim() === '') return null
 
   let dateObj: Date
 
   if (typeof date === 'string') {
     dateObj = parseISO(date)
     if (!isValid(dateObj)) {
-      const timestamp = Number(date)
+      const timestamp = Number(date.trim())
       if (!Number.isNaN(timestamp)) {
         dateObj = new Date(timestamp)
       }

--- a/app/utils/date/parseDate.ts
+++ b/app/utils/date/parseDate.ts
@@ -16,14 +16,16 @@ import { isValid, parseISO } from 'date-fns'
  */
 export function parseDate(date: string | Date | number | null | undefined): Date | null {
   if (date === null || date === undefined) return null
-  if (typeof date === 'string' && date.trim() === '') return null
 
   let dateObj: Date
 
   if (typeof date === 'string') {
-    dateObj = parseISO(date)
+    const trimmed = date.trim()
+    if (trimmed === '') return null
+
+    dateObj = parseISO(trimmed)
     if (!isValid(dateObj)) {
-      const timestamp = Number(date.trim())
+      const timestamp = Number(trimmed)
       if (!Number.isNaN(timestamp)) {
         dateObj = new Date(timestamp)
       }

--- a/app/utils/date/parseDate.ts
+++ b/app/utils/date/parseDate.ts
@@ -1,0 +1,23 @@
+import { isValid, parseISO } from 'date-fns'
+
+export function parseDate(date: string | Date | number | null | undefined): Date | null {
+  if (!date) return null
+
+  let dateObj: Date
+
+  if (typeof date === 'string') {
+    dateObj = parseISO(date)
+    if (!isValid(dateObj)) {
+      const timestamp = Number(date)
+      if (!Number.isNaN(timestamp)) {
+        dateObj = new Date(timestamp)
+      }
+    }
+  } else if (typeof date === 'number') {
+    dateObj = new Date(date)
+  } else {
+    dateObj = date
+  }
+
+  return isValid(dateObj) ? dateObj : null
+}

--- a/app/utils/date/parseDate.ts
+++ b/app/utils/date/parseDate.ts
@@ -1,7 +1,7 @@
 import { isValid, parseISO } from 'date-fns'
 
 export function parseDate(date: string | Date | number | null | undefined): Date | null {
-  if (!date) return null
+  if (date === null || date === undefined || date === '') return null
 
   let dateObj: Date
 

--- a/app/utils/date/toMonthAndYear.test.ts
+++ b/app/utils/date/toMonthAndYear.test.ts
@@ -17,4 +17,9 @@ describe('toMonthAndYear', () => {
   it('returns empty string for undefined input', () => {
     expect(toMonthAndYear(undefined)).toBe('')
   })
+
+  it('treats 0 as a valid epoch date (1970-01-01), not as a missing value', () => {
+    expect(toMonthAndYear(0)).toBe('Januar 1970')
+    expect(toMonthAndYear('0')).toBe('Januar 1970')
+  })
 })

--- a/app/utils/date/toMonthAndYear.test.ts
+++ b/app/utils/date/toMonthAndYear.test.ts
@@ -19,7 +19,12 @@ describe('toMonthAndYear', () => {
   })
 
   it('treats 0 as a valid epoch date (1970-01-01), not as a missing value', () => {
-    expect(toMonthAndYear(0)).toBe('Januar 1970')
-    expect(toMonthAndYear('0')).toBe('Januar 1970')
+    // Not asserting the exact "Januar 1970" string, since new Date(0) formats in the
+    // local timezone and could resolve to December 1969 in negative-offset timezones.
+    // We only assert that 0 is treated as a valid date (non-empty output), matching
+    // parseDate()'s documented contract that 0 is a valid epoch, not a missing value.
+    expect(toMonthAndYear(0)).not.toBe('')
+    expect(toMonthAndYear('0')).not.toBe('')
+    expect(toMonthAndYear(0)).toBe(toMonthAndYear(new Date(0)))
   })
 })

--- a/app/utils/date/toMonthAndYear.ts
+++ b/app/utils/date/toMonthAndYear.ts
@@ -1,4 +1,4 @@
-import { isValid, parseISO } from 'date-fns'
+import { parseDate } from './parseDate'
 
 /**
  * Formats a date string or Date object to Norwegian month and year format "januar 2028".
@@ -8,27 +8,8 @@ import { isValid, parseISO } from 'date-fns'
  * @returns Formatted date string in "Month Year" format or empty string if invalid
  */
 export function toMonthAndYear(date: string | Date | number | null | undefined): string {
-  if (!date) return ''
-
-  let dateObj: Date
-
-  if (typeof date === 'string') {
-    // Try to parse as ISO string
-    dateObj = parseISO(date)
-    if (!isValid(dateObj)) {
-      // Fallback: try to parse as timestamp string
-      const timestamp = Number(date)
-      if (!Number.isNaN(timestamp)) {
-        dateObj = new Date(timestamp)
-      }
-    }
-  } else if (typeof date === 'number') {
-    dateObj = new Date(date)
-  } else {
-    dateObj = date
-  }
-
-  if (!isValid(dateObj)) return ''
+  const dateObj = parseDate(date)
+  if (!dateObj) return ''
 
   const formatted = dateObj.toLocaleDateString('nb-NO', {
     month: 'long',


### PR DESCRIPTION
## Hva
Rydder opp i dato-utilities: ny felles `parseDate()`, forenkler eksisterende funksjoner.

## Endringer
- Ny `parseDate.ts`: felles parsing-funksjon som håndterer ISO-datostrenger og Unix-timestamps (som tall eller tallstreng), inkl. epoch (0)
- Forenkler `formatDateToAge`, `formatDateToNorwegian`, `toMonthAndYear` (bruker parseDate internt)
- Tester for parseDate, inkludert epoch-edge-case

## Avhengigheter
Ingen — kan merges uavhengig. Bør merges **før** refactor/delte-komponenter-og-hooks (som bruker `parseDate` i `vurder-samboer/index.tsx`).
