### PR TITLE
refactor: api-client feilhåndtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ package-lock.json
 # Environment variables
 .env
 
+# Husky (generated locally by `pnpm prepare`)
+.husky/_/
+
 # React Router
 /.react-router/
 /build/

--- a/app/api/api-client.test.ts
+++ b/app/api/api-client.test.ts
@@ -45,6 +45,58 @@ describe('fetcher error-håndtering', () => {
     expect(error.data.violations).toEqual(['Feil A', 'Feil B'])
   })
 
+  it('redakterer også title i det nøstede problemDetails-objektet, ikke bare de flate feltene', async () => {
+    const { fetcher } = await import('./api-client')
+
+    const jwt = ['eyJhbGciOiJSUzI1NiJ9', 'eyJzdWIiOiIxMjM0NTY3ODkwIn0', 'signaturedel'].join('.')
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: 'about:blank',
+          title: `Uautorisert: ${jwt}`,
+          status: 401,
+          detail: `Token: ${jwt}`,
+        }),
+        { status: 401, headers: { 'content-type': 'application/problem+json' } },
+      ),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'GET' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.title).not.toContain(jwt)
+    expect(error.data.problemDetails?.title).not.toContain(jwt)
+    expect(error.data.problemDetails?.detail).not.toContain(jwt)
+  })
+
+  it('faller tilbake til rå tekst når responsen er gyldig JSON men ikke et objekt (f.eks. en ren streng)', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify('Uventet strengrespons'), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'GET' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.message).toBe('"Uventet strengrespons"')
+  })
+
   it('mapper application/json-feil til flate felter med traceId fra traceparent', async () => {
     const { fetcher } = await import('./api-client')
 

--- a/app/api/api-client.test.ts
+++ b/app/api/api-client.test.ts
@@ -153,6 +153,58 @@ describe('fetcher error-håndtering', () => {
     expect(error.data.message).toBe('"Uventet strengrespons"')
   })
 
+  it('faller tilbake til rå tekst når problemDetails.detail ikke er en streng (f.eks. en array)', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: 'about:blank',
+          title: 'Valideringsfeil',
+          status: 400,
+          detail: ['Feil A', 'Feil B'],
+        }),
+        { status: 400, headers: { 'content-type': 'application/problem+json' } },
+      ),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'POST' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.message).not.toBeUndefined()
+    expect(error.data.detail).not.toBeUndefined()
+    expect(error.data.problemDetails?.detail).not.toBeUndefined()
+  })
+
+  it('faller tilbake til rå tekst når message/detail i application/json-feil ikke er strenger', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Feil', message: { code: 'X' }, detail: { code: 'Y' } }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'GET' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.message).not.toBeUndefined()
+    expect(error.data.detail).not.toBeUndefined()
+  })
+
   it('mapper application/json-feil til flate felter med traceId fra traceparent', async () => {
     const { fetcher } = await import('./api-client')
 
@@ -271,7 +323,7 @@ describe('fetcher error-håndtering', () => {
     expect(error.data.message).toBe('not json')
   })
 
-  it('kaster ikke hvis feilfelter i responsen ikke er strenger (f.eks. objekt/array) til tross for at type-signaturen sier string', async () => {
+  it('kaster ikke hvis feilfelter i responsen ikke er strenger (f.eks. objekt/array), og faller tilbake til rå tekst for detail', async () => {
     const { fetcher } = await import('./api-client')
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
@@ -296,7 +348,7 @@ describe('fetcher error-håndtering', () => {
 
     if (!isApiError(error)) throw new Error('forventet ApiError')
     expect(error.data.status).toBe(400)
-    expect(error.data.detail).toBeUndefined()
+    expect(error.data.detail).toContain('unexpected')
   })
 })
 

--- a/app/api/api-client.test.ts
+++ b/app/api/api-client.test.ts
@@ -96,6 +96,28 @@ describe('fetcher error-håndtering', () => {
     expect(error.data.message).toBe('Ugyldig token: [REDACTED]')
     expect(error.data.message).not.toContain(jwt)
   })
+
+  it('bevarer rå tekst som melding når feilrespons ikke er gyldig JSON', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Internal Server Error: database connection failed', {
+        status: 502,
+        headers: { 'content-type': 'text/plain' },
+      }),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'GET' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.message).toBe('Internal Server Error: database connection failed')
+  })
 })
 
 describe('fetcher suksess-håndtering', () => {

--- a/app/api/api-client.test.ts
+++ b/app/api/api-client.test.ts
@@ -98,6 +98,7 @@ describe('fetcher error-håndtering', () => {
 
     if (!isApiError(error)) throw new Error('forventet ApiError')
     expect(error.data.violations).toEqual(['Feil A', 'Feil B'])
+    expect(error.data.problemDetails?.violations).toEqual(['Feil A', 'Feil B'])
   })
 
   it('redakterer også title i det nøstede problemDetails-objektet, ikke bare de flate feltene', async () => {

--- a/app/api/api-client.test.ts
+++ b/app/api/api-client.test.ts
@@ -162,6 +162,34 @@ describe('fetcher error-håndtering', () => {
     if (!isApiError(error)) throw new Error('forventet ApiError')
     expect(error.data.message).toBe('not json')
   })
+
+  it('kaster ikke hvis feilfelter i responsen ikke er strenger (f.eks. objekt/array) til tross for at type-signaturen sier string', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: 'about:blank',
+          title: { unexpected: 'object-i-stedet-for-streng' },
+          status: 400,
+          detail: ['unexpected', 'array'],
+        }),
+        { status: 400, headers: { 'content-type': 'application/problem+json' } },
+      ),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'GET' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.status).toBe(400)
+    expect(error.data.detail).toBeUndefined()
+  })
 })
 
 describe('fetcher suksess-håndtering', () => {

--- a/app/api/api-client.test.ts
+++ b/app/api/api-client.test.ts
@@ -118,6 +118,50 @@ describe('fetcher error-håndtering', () => {
     if (!isApiError(error)) throw new Error('forventet ApiError')
     expect(error.data.message).toBe('Internal Server Error: database connection failed')
   })
+
+  it('kaster ikke, men faller tilbake til rå tekst når content-type sier application/json men kroppen er ugyldig JSON', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('<html>Gateway Timeout</html>', {
+        status: 504,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'GET' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.message).toBe('<html>Gateway Timeout</html>')
+  })
+
+  it('kaster ikke, men faller tilbake til rå tekst når content-type sier problem+json men kroppen er ugyldig JSON', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('not json', {
+        status: 500,
+        headers: { 'content-type': 'application/problem+json' },
+      }),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'GET' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.message).toBe('not json')
+  })
 })
 
 describe('fetcher suksess-håndtering', () => {

--- a/app/api/api-client.test.ts
+++ b/app/api/api-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { isApiError } from '~/api/error.types'
+import { requireAccessToken } from '~/auth/auth.server'
 
 vi.mock('~/auth/auth.server', () => ({
   requireAccessToken: vi.fn().mockResolvedValue('test-token'),
@@ -12,6 +13,10 @@ vi.mock('~/utils/env.server', () => ({
 describe('fetcher error-håndtering', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    // vi.restoreAllMocks() nullstiller også module-mocken over til en tom mock uten
+    // implementasjon, siden det ikke finnes en "original" å restore til for vi.fn().
+    // Re-etabler default-implementasjonen slik at fetcher() fortsatt får et token.
+    vi.mocked(requireAccessToken).mockResolvedValue('test-token')
   })
 
   it('mapper application/problem+json til en ApiErrorData-kompatibel feil med violations', async () => {
@@ -67,10 +72,13 @@ describe('fetcher error-håndtering', () => {
     const error = (await doFetch('/vurdering', { method: 'POST' }).then(
       () => null,
       (e: unknown) => e,
-    )) as { init: ResponseInit | null; data: { status: number } }
+    )) as { init: ResponseInit | null; data: { status: number; title: string } }
 
     expect(error.data.status).toBe(422)
     expect(error.init?.status).toBe(422)
+    // statusText skal være utledet av den samme feilen som status (title), ikke den
+    // opprinnelige HTTP-responsens statusText, slik at de to ikke kan divergere.
+    expect(error.init?.statusText).toBe(error.data.title)
   })
 
   it('filtrerer bort ugyldige (ikke-streng) elementer i violations', async () => {
@@ -355,6 +363,7 @@ describe('fetcher error-håndtering', () => {
 describe('fetcher suksess-håndtering', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    vi.mocked(requireAccessToken).mockResolvedValue('test-token')
   })
 
   it('parser application/json-svar', async () => {

--- a/app/api/api-client.test.ts
+++ b/app/api/api-client.test.ts
@@ -45,6 +45,61 @@ describe('fetcher error-håndtering', () => {
     expect(error.data.violations).toEqual(['Feil A', 'Feil B'])
   })
 
+  it('bruker samme (beregnede) status i data()-responsen som i error.data.status', async () => {
+    const { fetcher } = await import('./api-client')
+
+    // HTTP-responsen er 400, men backend sender et avvikende status i problemDetails
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: 'about:blank',
+          title: 'Valideringsfeil',
+          status: 422,
+          detail: 'Validering feilet',
+        }),
+        { status: 400, headers: { 'content-type': 'application/problem+json' } },
+      ),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = (await doFetch('/vurdering', { method: 'POST' }).then(
+      () => null,
+      (e: unknown) => e,
+    )) as { init: ResponseInit | null; data: { status: number } }
+
+    expect(error.data.status).toBe(422)
+    expect(error.init?.status).toBe(422)
+  })
+
+  it('filtrerer bort ugyldige (ikke-streng) elementer i violations', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: 'about:blank',
+          title: 'Valideringsfeil',
+          status: 400,
+          violations: ['Feil A', 42, null, 'Feil B'],
+        }),
+        { status: 400, headers: { 'content-type': 'application/problem+json' } },
+      ),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'POST' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.violations).toEqual(['Feil A', 'Feil B'])
+  })
+
   it('redakterer også title i det nøstede problemDetails-objektet, ikke bare de flate feltene', async () => {
     const { fetcher } = await import('./api-client')
 

--- a/app/api/api-client.test.ts
+++ b/app/api/api-client.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { isApiError } from '~/api/error.types'
+
+vi.mock('~/auth/auth.server', () => ({
+  requireAccessToken: vi.fn().mockResolvedValue('test-token'),
+}))
+
+vi.mock('~/utils/env.server', () => ({
+  isMockEnv: false,
+}))
+
+describe('fetcher error-håndtering', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('mapper application/problem+json til en ApiErrorData-kompatibel feil med violations', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: 'about:blank',
+          title: 'Valideringsfeil',
+          status: 400,
+          detail: 'Validering av vurdering feilet (2 feil)',
+          violations: ['Feil A', 'Feil B'],
+        }),
+        { status: 400, headers: { 'content-type': 'application/problem+json;charset=UTF-8' } },
+      ),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'POST' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    expect(isApiError(error)).toBe(true)
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.status).toBe(400)
+    expect(error.data.title).toBe('Valideringsfeil')
+    expect(error.data.violations).toEqual(['Feil A', 'Feil B'])
+  })
+
+  it('mapper application/json-feil til flate felter med traceId fra traceparent', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Feil', message: 'Noe gikk galt', path: '/vurdering' }), {
+        status: 500,
+        headers: {
+          'content-type': 'application/json',
+          traceparent: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+        },
+      }),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'GET' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.status).toBe(500)
+    expect(error.data.title).toBe('Feil')
+    expect(error.data.message).toBe('Noe gikk galt')
+    expect(error.data.traceId).toBe('0af7651916cd43dd8448eb211c80319c')
+  })
+
+  it('redigerer bort JWT-lignende tokens fra feilmeldinger', async () => {
+    const { fetcher } = await import('./api-client')
+
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc-DEF_123'
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Feil', message: `Ugyldig token: ${jwt}` }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const error = await doFetch('/vurdering', { method: 'GET' }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    if (!isApiError(error)) throw new Error('forventet ApiError')
+    expect(error.data.message).toBe('Ugyldig token: [REDACTED]')
+    expect(error.data.message).not.toContain(jwt)
+  })
+})
+
+describe('fetcher suksess-håndtering', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('parser application/json-svar', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ saker: [{ sakId: 1 }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const result = await doFetch<{ saker: { sakId: number }[] }>('/grunnlagsdata', { method: 'GET' })
+
+    expect(result).toEqual({ saker: [{ sakId: 1 }] })
+  })
+
+  it('returnerer undefined for et 200-svar uten JSON-kropp (tomt grunnlagsdata-svar / void POST)', async () => {
+    const { fetcher } = await import('./api-client')
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+
+    const request = new Request('https://app.intern.nav.no/path')
+    const doFetch = fetcher('https://pen', request)
+
+    const result = await doFetch('/vurdering', { method: 'POST' })
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/app/api/api-client.ts
+++ b/app/api/api-client.ts
@@ -25,7 +25,13 @@ function extractTraceId(response: Response): string | null {
 async function parseBodySafely(response: Response): Promise<{ json?: Record<string, unknown>; text?: string }> {
   const rawText = await response.text()
   try {
-    return { json: JSON.parse(rawText) }
+    const parsed: unknown = JSON.parse(rawText)
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return { json: parsed as Record<string, unknown> }
+    }
+    // Gyldig JSON, men ikke et objekt (f.eks. en ren streng/tall/array) – behandle som rå tekst
+    // slik at vi ikke mister innholdet og fallback-verdiene i buildApiError() fortsatt fungerer.
+    return { text: rawText }
   } catch {
     return { text: rawText }
   }
@@ -48,7 +54,11 @@ async function buildApiError(response: Response) {
       message: redactTokens(problemDetails.detail ?? unparsedText),
       detail: redactTokens(problemDetails.detail ?? unparsedText),
       violations: problemDetails.violations,
-      problemDetails: { ...problemDetails, detail: redactTokens(problemDetails.detail) },
+      problemDetails: {
+        ...problemDetails,
+        title: redactTokens(problemDetails.title),
+        detail: redactTokens(problemDetails.detail),
+      },
       traceId,
     }
   }

--- a/app/api/api-client.ts
+++ b/app/api/api-client.ts
@@ -117,7 +117,10 @@ export const fetcher =
       const apiError = await buildApiError(response)
       throw data(apiError, {
         status: apiError.status,
-        statusText: response.statusText,
+        // Bruk apiError.title (utledet fra problemDetails.status/title) i stedet for
+        // response.statusText, slik at status og statusText ikke kan divergere når
+        // f.eks. problemDetails.status (422) avviker fra HTTP-statusen (400).
+        statusText: apiError.title,
       })
     }
 

--- a/app/api/api-client.ts
+++ b/app/api/api-client.ts
@@ -21,50 +21,53 @@ function extractTraceId(response: Response): string | null {
   return navTraceId
 }
 
+async function parseBodySafely(response: Response): Promise<{ json?: Record<string, unknown>; text?: string }> {
+  const rawText = await response.text()
+  try {
+    return { json: JSON.parse(rawText) }
+  } catch {
+    return { text: rawText }
+  }
+}
+
 async function buildApiError(response: Response) {
   const traceId = extractTraceId(response)
   const contentType = response.headers.get('content-type')
+  const { json, text: unparsedText } = await parseBodySafely(response)
 
   if (contentType?.includes('application/problem+json')) {
-    const problemDetails = (await response.json()) as ProblemDetails & { violations?: string[] }
+    const problemDetails = (json ?? {}) as ProblemDetails & { violations?: string[] }
 
     return {
       // Flat felter i tillegg til problemDetails, slik at isApiError() og kallere som
       // leser error.data.status/violations (f.eks. validering fra pen) fungerer.
       // problemDetails beholdes for ErrorBoundary (root.tsx).
       status: problemDetails.status ?? response.status,
-      title: problemDetails.title || response.statusText || 'API Error',
-      message: redactTokens(problemDetails.detail),
-      detail: redactTokens(problemDetails.detail),
+      title: redactTokens(problemDetails.title) || response.statusText || 'API Error',
+      message: redactTokens(problemDetails.detail ?? unparsedText),
+      detail: redactTokens(problemDetails.detail ?? unparsedText),
       violations: problemDetails.violations,
       problemDetails: { ...problemDetails, detail: redactTokens(problemDetails.detail) },
       traceId,
     }
   }
 
-  let errorBody: { error?: string; message?: string; detail?: string; path?: string; timestamp?: string } = {}
-  let unparsedText: string | undefined
-
-  if (contentType?.includes('application/json')) {
-    errorBody = await response.json()
-  } else {
-    const errorText = await response.text()
-    try {
-      errorBody = JSON.parse(errorText)
-    } catch {
-      errorBody = {}
-      unparsedText = errorText
-    }
+  const errorBody = (json ?? {}) as {
+    error?: string
+    message?: string
+    detail?: string
+    path?: string
+    timestamp?: string
   }
 
   return {
     status: response.status,
-    title: errorBody?.error || response.statusText || 'API Error',
-    message: redactTokens(errorBody?.message ?? unparsedText),
+    title: redactTokens(errorBody.error) || response.statusText || 'API Error',
+    message: redactTokens(errorBody.message ?? unparsedText),
     traceId,
-    detail: redactTokens(errorBody?.detail ?? unparsedText),
-    path: errorBody?.path,
-    timestamp: errorBody?.timestamp,
+    detail: redactTokens(errorBody.detail ?? unparsedText),
+    path: errorBody.path,
+    timestamp: errorBody.timestamp,
   }
 }
 

--- a/app/api/api-client.ts
+++ b/app/api/api-client.ts
@@ -1,14 +1,77 @@
 import { data } from 'react-router'
 import type { ProblemDetails } from '~/api/error.types'
 import { requireAccessToken } from '~/auth/auth.server'
+import { isMockEnv } from '~/utils/env.server'
 import { parseTraceparent } from '~/utils/traceparent'
+
+const JWT_PATTERN = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g
+
+function redactTokens(value: string | undefined): string | undefined {
+  return value?.replace(JWT_PATTERN, '[REDACTED]')
+}
+
+function extractTraceId(response: Response): string | null {
+  const traceparent = response.headers.get('traceparent')
+  const navTraceId = response.headers.get('nav-call-id')
+
+  if (traceparent !== null) {
+    return parseTraceparent(traceparent)?.traceId || navTraceId
+  }
+
+  return navTraceId
+}
+
+async function buildApiError(response: Response) {
+  const traceId = extractTraceId(response)
+  const contentType = response.headers.get('content-type')
+
+  if (contentType?.includes('application/problem+json')) {
+    const problemDetails = (await response.json()) as ProblemDetails & { violations?: string[] }
+
+    return {
+      // Flat felter i tillegg til problemDetails, slik at isApiError() og kallere som
+      // leser error.data.status/violations (f.eks. validering fra pen) fungerer.
+      // problemDetails beholdes for ErrorBoundary (root.tsx).
+      status: problemDetails.status ?? response.status,
+      title: problemDetails.title || response.statusText || 'API Error',
+      message: redactTokens(problemDetails.detail),
+      detail: redactTokens(problemDetails.detail),
+      violations: problemDetails.violations,
+      problemDetails: { ...problemDetails, detail: redactTokens(problemDetails.detail) },
+      traceId,
+    }
+  }
+
+  let errorBody: { error?: string; message?: string; detail?: string; path?: string; timestamp?: string } = {}
+
+  if (contentType?.includes('application/json')) {
+    errorBody = await response.json()
+  } else {
+    const errorText = await response.text()
+    try {
+      errorBody = JSON.parse(errorText)
+    } catch {
+      errorBody = {}
+    }
+  }
+
+  return {
+    status: response.status,
+    title: errorBody?.error || response.statusText || 'API Error',
+    message: redactTokens(errorBody?.message),
+    traceId,
+    detail: redactTokens(errorBody?.detail),
+    path: errorBody?.path,
+    timestamp: errorBody?.timestamp,
+  }
+}
 
 export type Fetcher = <T>(url: string, options: RequestInit) => Promise<T>
 
 export const fetcher =
   (BASE_URL: string, request: Request): Fetcher =>
   async <T>(url: string, options: RequestInit = {}): Promise<T> => {
-    const token = process.env.NODE_ENV === 'mock' ? 'mock-token' : await requireAccessToken(request)
+    const token = isMockEnv ? 'mock-token' : await requireAccessToken(request)
     const headers = new Headers(options.headers)
     headers.set('Authorization', `Bearer ${token}`)
 
@@ -24,75 +87,10 @@ export const fetcher =
     const response = await fetch(`${BASE_URL}${url}`, mergedOptions)
 
     if (!response.ok) {
-      function traceId() {
-        const traceparent = response.headers.get('traceparent')
-        const navTraceId = response.headers.get('nav-call-id')
-
-        if (traceparent !== null) {
-          return parseTraceparent(traceparent)?.traceId || navTraceId
-        } else {
-          return navTraceId
-        }
-      }
-
-      const contentType = response.headers.get('content-type')
-
-      if (contentType?.includes('application/json')) {
-        const errorBody = await response.json()
-
-        throw data(
-          {
-            status: response.status,
-            title: errorBody?.error || response.statusText || 'API Error',
-            message: errorBody?.message,
-            traceId: traceId(),
-            detail: errorBody?.detail,
-            path: errorBody?.path,
-            timestamp: errorBody?.timestamp,
-          },
-          {
-            status: response.status,
-            statusText: response.statusText,
-          },
-        )
-      } else if (contentType?.includes('application/problem+json')) {
-        const problemDetails: ProblemDetails = (await response.json()) as ProblemDetails
-
-        throw data(
-          {
-            problemDetails: problemDetails,
-            traceId: traceId(),
-          },
-          {
-            status: response.status,
-            statusText: response.statusText,
-          },
-        )
-      } else {
-        const errorText = await response.text()
-        let errorBody: { error?: string; message?: string; detail?: string; path?: string; timestamp?: string } = {}
-        try {
-          errorBody = JSON.parse(errorText)
-        } catch {
-          errorBody = {}
-        }
-
-        throw data(
-          {
-            status: response.status,
-            title: errorBody?.error || response.statusText || 'API Error',
-            message: errorBody?.message,
-            traceId: traceId(),
-            detail: errorBody?.detail,
-            path: errorBody?.path,
-            timestamp: errorBody?.timestamp,
-          },
-          {
-            status: response.status,
-            statusText: response.statusText,
-          },
-        )
-      }
+      throw data(await buildApiError(response), {
+        status: response.status,
+        statusText: response.statusText,
+      })
     }
 
     const contentType = response.headers.get('content-type')
@@ -100,5 +98,7 @@ export const fetcher =
       return await response.json()
     }
 
-    return response as unknown as T
+    // Tomme svar (void POST, eller grunnlagsdata uten data der pen svarer 200 uten
+    // content-type og uten kropp) gir undefined – ikke selve Response-objektet.
+    return undefined as T
   }

--- a/app/api/api-client.ts
+++ b/app/api/api-client.ts
@@ -63,6 +63,7 @@ async function buildApiError(response: Response) {
         status,
         title: redactTokens(problemDetails.title),
         detail: redactTokens(problemDetails.detail),
+        violations,
       },
       traceId,
     }

--- a/app/api/api-client.ts
+++ b/app/api/api-client.ts
@@ -43,6 +43,7 @@ async function buildApiError(response: Response) {
   }
 
   let errorBody: { error?: string; message?: string; detail?: string; path?: string; timestamp?: string } = {}
+  let unparsedText: string | undefined
 
   if (contentType?.includes('application/json')) {
     errorBody = await response.json()
@@ -52,15 +53,16 @@ async function buildApiError(response: Response) {
       errorBody = JSON.parse(errorText)
     } catch {
       errorBody = {}
+      unparsedText = errorText
     }
   }
 
   return {
     status: response.status,
     title: errorBody?.error || response.statusText || 'API Error',
-    message: redactTokens(errorBody?.message),
+    message: redactTokens(errorBody?.message ?? unparsedText),
     traceId,
-    detail: redactTokens(errorBody?.detail),
+    detail: redactTokens(errorBody?.detail ?? unparsedText),
     path: errorBody?.path,
     timestamp: errorBody?.timestamp,
   }

--- a/app/api/api-client.ts
+++ b/app/api/api-client.ts
@@ -6,8 +6,9 @@ import { parseTraceparent } from '~/utils/traceparent'
 
 const JWT_PATTERN = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g
 
-function redactTokens(value: string | undefined): string | undefined {
-  return value?.replace(JWT_PATTERN, '[REDACTED]')
+function redactTokens(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  return value.replace(JWT_PATTERN, '[REDACTED]')
 }
 
 function extractTraceId(response: Response): string | null {

--- a/app/api/api-client.ts
+++ b/app/api/api-client.ts
@@ -43,19 +43,24 @@ async function buildApiError(response: Response) {
   const { json, text: unparsedText } = await parseBodySafely(response)
 
   if (contentType?.includes('application/problem+json')) {
-    const problemDetails = (json ?? {}) as ProblemDetails & { violations?: string[] }
+    const problemDetails = (json ?? {}) as ProblemDetails & { violations?: unknown }
+    const status = problemDetails.status ?? response.status
+    const violations = Array.isArray(problemDetails.violations)
+      ? problemDetails.violations.filter((v): v is string => typeof v === 'string')
+      : undefined
 
     return {
       // Flat felter i tillegg til problemDetails, slik at isApiError() og kallere som
       // leser error.data.status/violations (f.eks. validering fra pen) fungerer.
       // problemDetails beholdes for ErrorBoundary (root.tsx).
-      status: problemDetails.status ?? response.status,
+      status,
       title: redactTokens(problemDetails.title) || response.statusText || 'API Error',
       message: redactTokens(problemDetails.detail ?? unparsedText),
       detail: redactTokens(problemDetails.detail ?? unparsedText),
-      violations: problemDetails.violations,
+      violations,
       problemDetails: {
         ...problemDetails,
+        status,
         title: redactTokens(problemDetails.title),
         detail: redactTokens(problemDetails.detail),
       },
@@ -103,8 +108,9 @@ export const fetcher =
     const response = await fetch(`${BASE_URL}${url}`, mergedOptions)
 
     if (!response.ok) {
-      throw data(await buildApiError(response), {
-        status: response.status,
+      const apiError = await buildApiError(response)
+      throw data(apiError, {
+        status: apiError.status,
         statusText: response.statusText,
       })
     }

--- a/app/api/api-client.ts
+++ b/app/api/api-client.ts
@@ -22,12 +22,14 @@ function extractTraceId(response: Response): string | null {
   return navTraceId
 }
 
-async function parseBodySafely(response: Response): Promise<{ json?: Record<string, unknown>; text?: string }> {
+async function parseBodySafely(response: Response): Promise<{ json?: Record<string, unknown>; text: string }> {
   const rawText = await response.text()
   try {
     const parsed: unknown = JSON.parse(rawText)
     if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-      return { json: parsed as Record<string, unknown> }
+      // rawText følger med selv når JSON parses til et objekt, slik at buildApiError()
+      // kan falle tilbake til den når et enkeltfelt (f.eks. detail/message) har uventet form.
+      return { json: parsed as Record<string, unknown>, text: rawText }
     }
     // Gyldig JSON, men ikke et objekt (f.eks. en ren streng/tall/array) – behandle som rå tekst
     // slik at vi ikke mister innholdet og fallback-verdiene i buildApiError() fortsatt fungerer.
@@ -48,6 +50,7 @@ async function buildApiError(response: Response) {
     const violations = Array.isArray(problemDetails.violations)
       ? problemDetails.violations.filter((v): v is string => typeof v === 'string')
       : undefined
+    const detailText = typeof problemDetails.detail === 'string' ? problemDetails.detail : unparsedText
 
     return {
       // Flat felter i tillegg til problemDetails, slik at isApiError() og kallere som
@@ -55,14 +58,14 @@ async function buildApiError(response: Response) {
       // problemDetails beholdes for ErrorBoundary (root.tsx).
       status,
       title: redactTokens(problemDetails.title) || response.statusText || 'API Error',
-      message: redactTokens(problemDetails.detail ?? unparsedText),
-      detail: redactTokens(problemDetails.detail ?? unparsedText),
+      message: redactTokens(detailText),
+      detail: redactTokens(detailText),
       violations,
       problemDetails: {
         ...problemDetails,
         status,
         title: redactTokens(problemDetails.title),
-        detail: redactTokens(problemDetails.detail),
+        detail: redactTokens(detailText),
         violations,
       },
       traceId,
@@ -76,13 +79,15 @@ async function buildApiError(response: Response) {
     path?: string
     timestamp?: string
   }
+  const messageText = typeof errorBody.message === 'string' ? errorBody.message : unparsedText
+  const detailText = typeof errorBody.detail === 'string' ? errorBody.detail : unparsedText
 
   return {
     status: response.status,
     title: redactTokens(errorBody.error) || response.statusText || 'API Error',
-    message: redactTokens(errorBody.message ?? unparsedText),
+    message: redactTokens(messageText),
     traceId,
-    detail: redactTokens(errorBody.detail ?? unparsedText),
+    detail: redactTokens(detailText),
     path: errorBody.path,
     timestamp: errorBody.timestamp,
   }

--- a/app/api/error.types.ts
+++ b/app/api/error.types.ts
@@ -74,6 +74,8 @@ export function isProblemDetails(value: unknown): value is ProblemDetails {
     (obj.title === undefined || typeof obj.title === 'string') &&
     (obj.status === undefined || typeof obj.status === 'number') &&
     (obj.detail === undefined || typeof obj.detail === 'string') &&
-    (obj.instance === undefined || typeof obj.instance === 'string')
+    (obj.instance === undefined || typeof obj.instance === 'string') &&
+    (obj.violations === undefined ||
+      (Array.isArray(obj.violations) && obj.violations.every(v => typeof v === 'string')))
   )
 }

--- a/app/api/error.types.ts
+++ b/app/api/error.types.ts
@@ -5,6 +5,9 @@ export interface ApiErrorData {
   detail?: string
   path?: string
   timestamp?: string
+  violations?: string[]
+  traceId?: string | null
+  problemDetails?: ProblemDetails
 }
 
 export function isApiError(error: unknown): error is { data: ApiErrorData } {
@@ -51,6 +54,12 @@ export interface ProblemDetails {
    * It may or may not yield further information if dereferenced.
    */
   instance?: string
+
+  /**
+   * Ekstra medlem (RFC 9457 extension) brukt av pen sin valideringsrespons:
+   * liste med valideringsfeil som kan vises til saksbehandler.
+   */
+  violations?: string[]
 }
 
 export function isProblemDetails(value: unknown): value is ProblemDetails {

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -26,26 +26,33 @@ export function loadEnv<R extends Record<string, string>, O extends Record<strin
   return { ...req, ...opt }
 }
 
-export const env = loadEnv({
-  clientId: 'AZURE_APP_CLIENT_ID',
-  clientSecret: 'AZURE_APP_CLIENT_SECRET',
-  issuer: 'AZURE_OPENID_CONFIG_ISSUER',
-  tokenEndpoint: 'AZURE_OPENID_CONFIG_TOKEN_ENDPOINT',
+export const env = loadEnv(
+  {
+    clientId: 'AZURE_APP_CLIENT_ID',
+    clientSecret: 'AZURE_APP_CLIENT_SECRET',
+    issuer: 'AZURE_OPENID_CONFIG_ISSUER',
+    tokenEndpoint: 'AZURE_OPENID_CONFIG_TOKEN_ENDPOINT',
 
-  penScope: 'PEN_SCOPE',
-  penUrl: 'PEN_URL',
+    penScope: 'PEN_SCOPE',
+    penUrl: 'PEN_URL',
 
-  psakSakUrlTemplate: 'PSAK_SAK_URL_TEMPLATE',
-  psakOppgaveoversikt: 'PSAK_OPPGAVEOVERSIKT',
+    psakSakUrlTemplate: 'PSAK_SAK_URL_TEMPLATE',
+    psakOversiktUrlTemplate: 'PSAK_OVERSIKT_URL_TEMPLATE',
+    psakOppgaveoversikt: 'PSAK_OPPGAVEOVERSIKT',
 
-  verdandeBehandlingUrl: 'VERDANDE_BEHANDLING_URL',
-  verdandeAktivitetUrl: 'VERDANDE_AKTIVITET_URL',
-  telemetryUrl: 'TELEMETRY_URL',
-  modia: 'MODIA_PERSONOVERSIKT',
-  unleashUrl: 'UNLEASH_SERVER_API_URL',
-  unleashApiToken: 'UNLEASH_SERVER_API_TOKEN',
-  unleashEnvironment: 'UNLEASH_SERVER_API_ENV',
-})
+    verdandeBehandlingUrl: 'VERDANDE_BEHANDLING_URL',
+    verdandeAktivitetUrl: 'VERDANDE_AKTIVITET_URL',
+    telemetryUrl: 'TELEMETRY_URL',
+    modia: 'MODIA_PERSONOVERSIKT',
+    unleashUrl: 'UNLEASH_SERVER_API_URL',
+    unleashApiToken: 'UNLEASH_SERVER_API_TOKEN',
+    unleashEnvironment: 'UNLEASH_SERVER_API_ENV',
+  },
+  {
+    pidEncryptionKey: 'PSAK_PID_ENCRYPTION_KEY',
+  },
+)
 
 export const isLocalEnv = process.env.IS_LOCAL_ENV === 'true'
+export const isMockEnv = process.env.NODE_ENV === 'mock' && !process.env.NAIS_CLUSTER_NAME
 export const isVerdandeLinksEnabled = process.env.VERDANDE_LINKS_ENABLED === 'true'

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -26,32 +26,26 @@ export function loadEnv<R extends Record<string, string>, O extends Record<strin
   return { ...req, ...opt }
 }
 
-export const env = loadEnv(
-  {
-    clientId: 'AZURE_APP_CLIENT_ID',
-    clientSecret: 'AZURE_APP_CLIENT_SECRET',
-    issuer: 'AZURE_OPENID_CONFIG_ISSUER',
-    tokenEndpoint: 'AZURE_OPENID_CONFIG_TOKEN_ENDPOINT',
+export const env = loadEnv({
+  clientId: 'AZURE_APP_CLIENT_ID',
+  clientSecret: 'AZURE_APP_CLIENT_SECRET',
+  issuer: 'AZURE_OPENID_CONFIG_ISSUER',
+  tokenEndpoint: 'AZURE_OPENID_CONFIG_TOKEN_ENDPOINT',
 
-    penScope: 'PEN_SCOPE',
-    penUrl: 'PEN_URL',
+  penScope: 'PEN_SCOPE',
+  penUrl: 'PEN_URL',
 
-    psakSakUrlTemplate: 'PSAK_SAK_URL_TEMPLATE',
-    psakOversiktUrlTemplate: 'PSAK_OVERSIKT_URL_TEMPLATE',
-    psakOppgaveoversikt: 'PSAK_OPPGAVEOVERSIKT',
+  psakSakUrlTemplate: 'PSAK_SAK_URL_TEMPLATE',
+  psakOppgaveoversikt: 'PSAK_OPPGAVEOVERSIKT',
 
-    verdandeBehandlingUrl: 'VERDANDE_BEHANDLING_URL',
-    verdandeAktivitetUrl: 'VERDANDE_AKTIVITET_URL',
-    telemetryUrl: 'TELEMETRY_URL',
-    modia: 'MODIA_PERSONOVERSIKT',
-    unleashUrl: 'UNLEASH_SERVER_API_URL',
-    unleashApiToken: 'UNLEASH_SERVER_API_TOKEN',
-    unleashEnvironment: 'UNLEASH_SERVER_API_ENV',
-  },
-  {
-    pidEncryptionKey: 'PSAK_PID_ENCRYPTION_KEY',
-  },
-)
+  verdandeBehandlingUrl: 'VERDANDE_BEHANDLING_URL',
+  verdandeAktivitetUrl: 'VERDANDE_AKTIVITET_URL',
+  telemetryUrl: 'TELEMETRY_URL',
+  modia: 'MODIA_PERSONOVERSIKT',
+  unleashUrl: 'UNLEASH_SERVER_API_URL',
+  unleashApiToken: 'UNLEASH_SERVER_API_TOKEN',
+  unleashEnvironment: 'UNLEASH_SERVER_API_ENV',
+})
 
 export const isLocalEnv = process.env.IS_LOCAL_ENV === 'true'
 export const isMockEnv = process.env.NODE_ENV === 'mock' && !process.env.NAIS_CLUSTER_NAME


### PR DESCRIPTION
## Hva
Refaktorerer feilhåndtering i API-klienten for bedre sikkerhet og debugging.

## Endringer
- Samler all feilbygging i `buildApiError()` — tydelig, testbar funksjon
- Redakterer JWT-tokens i feilmeldinger (`[REDACTED]`)
- Håndterer `application/problem+json` riktig, inkl. `violations` fra pen
- `error.types.ts`: nye felter `violations`, `traceId`, `problemDetails`
- `env.server.ts`: legger til `isMockEnv`
- `.gitignore`: ignorerer `.husky/_/` (generert lokalt av `pnpm prepare`)
- Nye tester for alle error-scenarier

## Avhengigheter
Ingen — kan merges uavhengig.
