### PR TITLE
ci: legg til pnpm-basert buildAndDeploySandbox workflow

### DIFF
--- a/.github/workflows/buildAndDeploySandbox.yml
+++ b/.github/workflows/buildAndDeploySandbox.yml
@@ -1,0 +1,60 @@
+name: Build and deploy sandbox
+
+on:
+  push:
+    branches:
+      - "sandbox"
+
+jobs:
+  build:
+    name: "build"
+    permissions:
+      contents: "read"
+      id-token: "write"
+      packages: "write"
+    runs-on: "ubuntu-latest"
+    outputs:
+      image: "${{ steps.docker-push.outputs.image }}"
+      telemetry: "${{ steps.docker-push.outputs.telemetry }}"
+    steps:
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: '11.9.0'
+      - uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e" # v6.4.0
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:ci
+      - run: pnpm run build
+      - run: pnpm prune --prod --ignore-scripts
+      - uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
+        id: docker-push
+        with:
+          team: pensjon-saksbehandling
+
+  deploy:
+    permissions:
+      contents: "read"
+      id-token: "write"
+    if: github.ref == 'refs/heads/sandbox'
+    needs: [build]
+    runs-on: 'ubuntu-latest'
+
+    strategy:
+      matrix:
+        include:
+          -  vars_file: vars-q2.yaml
+             cluster: dev-gcp
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb # v2
+        name: "deploy"
+        env:
+          CLUSTER: '${{ matrix.cluster }}'
+          IMAGE: "${{ needs.build.outputs.image }}"
+          RESOURCE: .nais/nais.yaml,.nais/unleash-apitoken.yaml
+          TELEMETRY: ${{ needs.build.outputs.telemetry }}
+          VARS: '.nais/${{ matrix.vars_file }}'


### PR DESCRIPTION
Erstatter det npm-baserte sandbox-workflow-scriptet som kun fantes på sandbox-branchen med en pnpm-konvertert versjon, i tråd med buildAndDeploy.yml på main. Deployer kun til dev-gcp (vars-q2.yaml), samme scope som det tidligere sandbox-only scriptet.