### PR TITLE
Endre dependabot oppsett

### DIFF
--- a/.github/SANDBOX.md
+++ b/.github/SANDBOX.md
@@ -1,0 +1,7 @@
+# This "dummy" file belongs to the "sandbox" git branch.
+
+Do not move or delete this file! It is here to detect whether changes
+have been included from the "sandbox" git branch or not.
+
+This is to prevent changes from the sandbox branch to end up
+in the main branch.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,66 @@
 version: 2
 updates:
   - package-ecosystem: docker
-    directory: "/"
+    directories:
+      - "/psak"
+      - "/psak-frontend"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      day: monday
+      time: '08:00'
+      timezone: 'Europe/Oslo'
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      day: monday
+      time: '08:00'
+      timezone: 'Europe/Oslo'
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 10
+    groups:
+      nais:
+        patterns:
+          - 'nais/*'
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 20
+      interval: weekly
+      day: monday
+      time: '08:00'
+      timezone: 'Europe/Oslo'
+    open-pull-requests-limit: 30
     cooldown:
       default-days: 7
+      exclude:
+        - '@navikt/*'
     groups:
-      aksel:
-        applies-to: version-updates
+      designsystemet:
         patterns:
-          - "@navikt/aksel*"
-          - "@navikt/ds*"
+          - '@navikt/ds*'
+          - '@navikt/aksel*'
+      grafana:
+        patterns:
+          - '@grafana/*'
+      storybook:
+        patterns:
+          - 'storybook'
+          - '@storybook/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
       react-router:
-        applies-to: version-updates
         patterns:
-          - "@react-router*"
-          - "react-router*"
+          - 'react-router'
+          - '@react-router/*'
+    ignore:
+      # Major versjon av @types/node skal følge Node.js versjonen i psak-frontend (v24).
+      - dependency-name: '@types/node'
+        versions: ['>= 25']

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,10 @@
+# Pakker må være minst 7 dager gamle før de lastes ned
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - "@navikt/*"
+
 allowBuilds:
   esbuild: true
   lefthook: true
   msw: true
   protobufjs: false
-minimumReleaseAgeExclude:
-  - '@react-router/dev@8.1.0'
-  - '@react-router/express@8.1.0'
-  - '@react-router/node@8.1.0'
-  - '@react-router/serve@8.1.0'
-  - react-router@8.1.0


### PR DESCRIPTION
- Sjekker ukentlig, kombinerer pakke grupper og filtrerer ut nav-pakker fra cooldown period.
- Også tilrettelegge 'pnpm outdated' & 'pnpm update' til å sjekke at pakker er minst 7 dager gamle.