### PR TITLE
feat: Update dependabot & pnpm-workspace config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,34 +3,62 @@ updates:
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      day: monday
+      time: '08:00'
+      timezone: 'Europe/Oslo'
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      day: monday
+      time: '08:00'
+      timezone: 'Europe/Oslo'
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 10
+    groups:
+      nais:
+        patterns:
+          - 'nais/*'
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 20
+      interval: weekly
+      day: monday
+      time: '08:00'
+      timezone: 'Europe/Oslo'
+    open-pull-requests-limit: 30
     cooldown:
       default-days: 7
+      exclude:
+        - '@navikt/*'
     groups:
-      aksel:
-        applies-to: version-updates
+      designsystemet:
         patterns:
-          - "@navikt/aksel*"
-          - "@navikt/ds*"
+          - '@navikt/ds*'
+          - '@navikt/aksel*'
+      grafana:
+        patterns:
+          - '@grafana/*'
+      storybook:
+        patterns:
+          - 'storybook'
+          - '@storybook/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
       react-router:
-        applies-to: version-updates
         patterns:
-          - "@react-router*"
-          - "react-router*"
+          - 'react-router'
+          - '@react-router/*'
+    ignore:
+      # Major versjon av @types/node skal følge Node.js versjonen i psak-frontend (v24).
+      - dependency-name: '@types/node'
+        versions: ['>= 25']

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,10 @@
+# Pakker må være minst 7 dager gamle før de lastes ned
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - "@navikt/*"
+
 allowBuilds:
   esbuild: true
   lefthook: true
   msw: true
   protobufjs: false
-minimumReleaseAgeExclude:
-  - '@react-router/dev@8.1.0'
-  - '@react-router/express@8.1.0'
-  - '@react-router/node@8.1.0'
-  - '@react-router/serve@8.1.0'
-  - react-router@8.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,3 @@ allowBuilds:
   esbuild: true
   lefthook: true
   msw: true
-  protobufjs: false


### PR DESCRIPTION
- Update dependabot to exclude nav modules in the 7 day cooldown, and update to weekly deps.
- Make pnpm-workspace also use the same 7 day window and exclude nav modules. So 'pnpm outdated' or 'pnpm update' will use same specs.