### PR TITLE
feat: oppdater opptjeningsgrunnlag

### DIFF
--- a/app/api/opptjeningstyper-api.server.ts
+++ b/app/api/opptjeningstyper-api.server.ts
@@ -1,0 +1,8 @@
+import type { OpptjeningstyperResponse } from '~/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/oppdater-grunnlag-types'
+import { env } from '~/utils/env.server'
+import { fetcher } from './api-client'
+
+export function fetchOpptjeningstyper(request: Request) {
+  const fetch = fetcher(`${env.penUrl}/api/saksbehandling/oppdater-opptjeningsgrunnlag`, request)
+  return fetch<OpptjeningstyperResponse>('/opptjeningstyper', { method: 'GET' })
+}

--- a/app/api/opptjeningstyper-api.server.ts
+++ b/app/api/opptjeningstyper-api.server.ts
@@ -1,4 +1,4 @@
-import type { OpptjeningstyperResponse } from '~/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/oppdater-grunnlag-types'
+import type { OpptjeningstyperResponse } from '~/types/opptjeningstyper'
 import { env } from '~/utils/env.server'
 import { fetcher } from './api-client'
 

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
@@ -115,6 +115,8 @@ export async function action({ params, request }: Route.ActionArgs) {
       )
     }
   }
+
+  return data({ errors: { utfall: 'Velg et utfall' } }, { status: 400 })
 }
 
 export default function AttesterRoute({ loaderData, actionData }: Route.ComponentProps) {
@@ -303,7 +305,7 @@ export default function AttesterRoute({ loaderData, actionData }: Route.Componen
 
         <Form method="post">
           <VStack gap="space-24">
-            <RadioGroup legend="Utfall" name="utfall" value={utfall} onChange={setUtfall}>
+            <RadioGroup legend="Utfall" name="utfall" value={utfall} onChange={setUtfall} error={errors?.utfall}>
               <Radio value="GODKJENN">Godkjenn</Radio>
               <Radio value="IKKE_GODKJENN">Returner til saksbehandler</Radio>
             </RadioGroup>

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
@@ -23,29 +23,18 @@ import { userContext } from '~/context/user-context'
 import { useIsSubmitting } from '~/hooks/use-is-submitting'
 import type { AktivitetOutletContext } from '~/types/aktivitetOutletContext'
 import { formatCurrencyNok } from '~/utils/currency'
+import { typeLabel } from '../oppdater-grunnlag'
 import type {
   DagpengerBackendDTO,
   Endringstype,
   ForstegangstjenesteBackendDTO,
   InntektBackendDTO,
   OppdaterOpptjeningVurdering,
-  OpptjeningstyperResponse,
 } from '../oppdater-grunnlag/oppdater-grunnlag-types'
 import type { Route } from './+types'
 
 type AttesterGrunnlag = {
   vurdering: OppdaterOpptjeningVurdering
-}
-
-function typeLabel(opptjeningstyper: OpptjeningstyperResponse, code: string): string {
-  const alle = [
-    ...opptjeningstyper.inntekt.typer,
-    ...opptjeningstyper.omsorg.typer,
-    ...opptjeningstyper.dagpenger.typer,
-    ...opptjeningstyper.forstegangstjeneste.typer,
-    ...opptjeningstyper.forstegangstjeneste.subTyper,
-  ]
-  return alle.find(t => t.code === code)?.description ?? code
 }
 
 function EndringstypeTag({ endringstype }: { endringstype: Endringstype }) {

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
@@ -1,0 +1,349 @@
+import { InformationSquareIcon } from '@navikt/aksel-icons'
+import {
+  BodyShort,
+  Button,
+  CopyButton,
+  Heading,
+  HStack,
+  InfoCard,
+  Page,
+  Radio,
+  RadioGroup,
+  Table,
+  Tag,
+  VStack,
+} from '@navikt/ds-react'
+import { useState } from 'react'
+import { data, Form, redirect, useOutletContext } from 'react-router'
+import { createAktivitetApi } from '~/api/aktivitet-api'
+import { createBehandlingApi } from '~/api/behandling-api'
+import { fetchOpptjeningstyper } from '~/api/opptjeningstyper-api.server'
+import styles from '~/common.module.css'
+import { userContext } from '~/context/user-context'
+import { useIsSubmitting } from '~/hooks/use-is-submitting'
+import type { AktivitetOutletContext } from '~/types/aktivitetOutletContext'
+import { formatCurrencyNok } from '~/utils/currency'
+import type {
+  DagpengerBackendDTO,
+  Endringstype,
+  ForstegangstjenesteBackendDTO,
+  InntektBackendDTO,
+  OppdaterOpptjeningVurdering,
+  OpptjeningstyperResponse,
+} from '../oppdater-grunnlag/oppdater-grunnlag-types'
+import type { Route } from './+types'
+
+type AttesterGrunnlag = {
+  vurdering: OppdaterOpptjeningVurdering
+}
+
+function typeLabel(opptjeningstyper: OpptjeningstyperResponse, code: string): string {
+  const alle = [
+    ...opptjeningstyper.inntekt.typer,
+    ...opptjeningstyper.omsorg.typer,
+    ...opptjeningstyper.dagpenger.typer,
+    ...opptjeningstyper.forstegangstjeneste.typer,
+    ...opptjeningstyper.forstegangstjeneste.subTyper,
+  ]
+  return alle.find(t => t.code === code)?.description ?? code
+}
+
+function EndringstypeTag({ endringstype }: { endringstype: Endringstype }) {
+  if (endringstype === 'OPPRETT')
+    return (
+      <Tag variant="success" size="small">
+        Ny
+      </Tag>
+    )
+  if (endringstype === 'OPPDATER')
+    return (
+      <Tag variant="warning" size="small">
+        Endret
+      </Tag>
+    )
+  return (
+    <Tag variant="error" size="small">
+      Slettet
+    </Tag>
+  )
+}
+
+export async function loader({ params, request, context }: Route.LoaderArgs) {
+  const { navident } = context.get(userContext)
+  const { behandlingId, aktivitetId } = params
+  const api = createAktivitetApi({ request, behandlingId, aktivitetId })
+
+  const [grunnlag, opptjeningstyper] = await Promise.all([
+    api.hentGrunnlagsdata<AttesterGrunnlag>(),
+    fetchOpptjeningstyper(request),
+  ])
+
+  return { navident, grunnlag, opptjeningstyper }
+}
+
+enum AttesteringUtfall {
+  GODKJENN = 'GODKJENN',
+  IKKE_GODKJENN = 'IKKE_GODKJENN',
+}
+
+export async function action({ params, request }: Route.ActionArgs) {
+  const { behandlingId } = params
+  const behandlingApi = createBehandlingApi({ request, behandlingId })
+
+  const formData = await request.formData()
+  const utfall = formData.get('utfall') as AttesteringUtfall
+
+  if (utfall === AttesteringUtfall.GODKJENN) {
+    await behandlingApi.attester()
+    return redirect(`/behandling/${behandlingId}/attestert-og-iverksatt`)
+  } else if (utfall === AttesteringUtfall.IKKE_GODKJENN) {
+    const begrunnelse = formData.get('begrunnelse') as string
+
+    if (begrunnelse) {
+      await behandlingApi.returnerTilSaksbehandler(begrunnelse)
+      return redirect(`/behandling/${behandlingId}/attestering-returnert-til-saksbehandler`)
+    } else {
+      return data(
+        {
+          errors: { begrunnelse: 'Begrunnelse må fylles ut' },
+          data: {
+            utfall,
+            begrunnelse,
+          },
+        },
+        { status: 400 },
+      )
+    }
+  }
+}
+
+export default function AttesterRoute({ loaderData, actionData }: Route.ComponentProps) {
+  const { errors, data: actionResultData } = actionData || {}
+  const { grunnlag, opptjeningstyper } = loaderData
+  const { avbrytAktivitet } = useOutletContext<AktivitetOutletContext>()
+  const isSubmitting = useIsSubmitting()
+  const [utfall, setUtfall] = useState<string>('')
+
+  const vurdering = grunnlag.vurdering
+
+  type InntektMedEndring = { endringstype: Endringstype; inntekt: InntektBackendDTO }
+  type DagpengerMedEndring = { endringstype: Endringstype; dagpenger: DagpengerBackendDTO }
+  type ForstegangstjenesteMedEndring = { endringstype: Endringstype; ft: ForstegangstjenesteBackendDTO }
+
+  const inntekter: InntektMedEndring[] = (vurdering?.inntektEndringer ?? []).flatMap(e =>
+    e.inntektListe.map(i => ({ endringstype: e.endringstype, inntekt: i })),
+  )
+
+  const dagpenger: DagpengerMedEndring[] = (vurdering?.dagpengerEndringer ?? []).flatMap(e =>
+    e.dagpengerListe.map(d => ({ endringstype: e.endringstype, dagpenger: d })),
+  )
+
+  const forstegangstjeneste: ForstegangstjenesteMedEndring[] = (vurdering?.forstegangstjenesteEndringer ?? []).map(
+    e => ({ endringstype: e.endringstype, ft: e.forstegangstjeneste }),
+  )
+
+  const harData = inntekter.length + dagpenger.length + forstegangstjeneste.length > 0
+
+  return (
+    <Page.Block gutters className={styles.page}>
+      <Heading size="medium" level="2">
+        Attester oppdatering av opptjeningsgrunnlag
+      </Heading>
+
+      <VStack gap="space-32">
+        {vurdering?.sakId != null && (
+          <HStack gap="space-4" align="center">
+            <BodyShort weight="semibold">Saksnummer:</BodyShort>
+            <CopyButton
+              size="small"
+              copyText={String(vurdering.sakId)}
+              text={String(vurdering.sakId)}
+              activeText="Kopiert!"
+              iconPosition="right"
+            />
+          </HStack>
+        )}
+        {harData ? (
+          <>
+            <InfoCard data-color="info">
+              <InfoCard.Header icon={<InformationSquareIcon aria-hidden />}>
+                <InfoCard.Title as="h3">Endringer til attestering</InfoCard.Title>
+              </InfoCard.Header>
+              <InfoCard.Content>Endringene vil først bli gjeldende ved godkjenning.</InfoCard.Content>
+            </InfoCard>
+
+            <VStack gap="space-32">
+              {inntekter.length > 0 && (
+                <div>
+                  <Heading size="xsmall" level="4" spacing>
+                    Inntekter
+                  </Heading>
+                  <Table size="small" style={{ width: '100%' }}>
+                    <Table.Header>
+                      <Table.Row>
+                        <Table.HeaderCell style={{ width: '7rem' }}>Endring</Table.HeaderCell>
+                        <Table.HeaderCell>Type</Table.HeaderCell>
+                        <Table.HeaderCell>År</Table.HeaderCell>
+                        <Table.HeaderCell>Beløp</Table.HeaderCell>
+                        <Table.HeaderCell>Skattekommune</Table.HeaderCell>
+                        <Table.HeaderCell>Kilde</Table.HeaderCell>
+                      </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                      {inntekter.map(({ endringstype, inntekt: i }) => (
+                        <Table.Row key={`${endringstype}-${i.inntektType}-${i.inntektAr}-${i.inntektId ?? ''}`}>
+                          <Table.DataCell>
+                            <EndringstypeTag endringstype={endringstype} />
+                          </Table.DataCell>
+                          <Table.DataCell>{typeLabel(opptjeningstyper, i.inntektType)}</Table.DataCell>
+                          <Table.DataCell>{i.inntektAr}</Table.DataCell>
+                          <Table.DataCell>{i.belop != null ? formatCurrencyNok(Number(i.belop)) : '–'}</Table.DataCell>
+                          <Table.DataCell>{i.kommune ?? '–'}</Table.DataCell>
+                          <Table.DataCell>{i.kilde ?? '–'}</Table.DataCell>
+                        </Table.Row>
+                      ))}
+                    </Table.Body>
+                  </Table>
+                </div>
+              )}
+
+              {dagpenger.length > 0 && (
+                <div>
+                  <Heading size="xsmall" level="4" spacing>
+                    Dagpenger
+                  </Heading>
+                  <Table size="small" style={{ width: '100%' }}>
+                    <Table.Header>
+                      <Table.Row>
+                        <Table.HeaderCell style={{ width: '7rem' }}>Endring</Table.HeaderCell>
+                        <Table.HeaderCell>Type</Table.HeaderCell>
+                        <Table.HeaderCell>År</Table.HeaderCell>
+                        <Table.HeaderCell>Uavkortet grunnlag</Table.HeaderCell>
+                        <Table.HeaderCell>Utbetalte dagpenger</Table.HeaderCell>
+                        <Table.HeaderCell>Ferietillegg</Table.HeaderCell>
+                        <Table.HeaderCell>Barnetillegg</Table.HeaderCell>
+                        <Table.HeaderCell>Kilde</Table.HeaderCell>
+                      </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                      {dagpenger.map(({ endringstype, dagpenger: d }) => (
+                        <Table.Row key={`${endringstype}-${d.dagpengerType}-${d.ar}-${d.dagpengerId ?? ''}`}>
+                          <Table.DataCell>
+                            <EndringstypeTag endringstype={endringstype} />
+                          </Table.DataCell>
+                          <Table.DataCell>{typeLabel(opptjeningstyper, d.dagpengerType)}</Table.DataCell>
+                          <Table.DataCell>{d.ar}</Table.DataCell>
+                          <Table.DataCell>
+                            {d.uavkortetDagpengegrunnlag != null
+                              ? formatCurrencyNok(Number(d.uavkortetDagpengegrunnlag))
+                              : '–'}
+                          </Table.DataCell>
+                          <Table.DataCell>
+                            {d.utbetalteDagpenger != null ? formatCurrencyNok(Number(d.utbetalteDagpenger)) : '–'}
+                          </Table.DataCell>
+                          <Table.DataCell>
+                            {d.ferietillegg != null ? formatCurrencyNok(Number(d.ferietillegg)) : '–'}
+                          </Table.DataCell>
+                          <Table.DataCell>
+                            {d.barnetillegg != null ? formatCurrencyNok(Number(d.barnetillegg)) : '–'}
+                          </Table.DataCell>
+                          <Table.DataCell>{d.kilde ?? '–'}</Table.DataCell>
+                        </Table.Row>
+                      ))}
+                    </Table.Body>
+                  </Table>
+                </div>
+              )}
+
+              {forstegangstjeneste.length > 0 && (
+                <div>
+                  <Heading size="xsmall" level="4" spacing>
+                    Førstegangstjeneste
+                  </Heading>
+                  <Table size="small" style={{ width: '100%' }}>
+                    <Table.Header>
+                      <Table.Row>
+                        <Table.HeaderCell style={{ width: '7rem' }}>Endring</Table.HeaderCell>
+                        <Table.HeaderCell>Type</Table.HeaderCell>
+                        <Table.HeaderCell>Periodetype</Table.HeaderCell>
+                        <Table.HeaderCell>FOM</Table.HeaderCell>
+                        <Table.HeaderCell>TOM</Table.HeaderCell>
+                        <Table.HeaderCell>Kilde</Table.HeaderCell>
+                      </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                      {forstegangstjeneste.map(({ endringstype, ft }) => {
+                        const periode = ft.forstegangstjenestePeriodeListe[0]
+                        return (
+                          <Table.Row key={`${endringstype}-${ft.tjenestestartDato}-${ft.forstegangstjenesteId ?? ''}`}>
+                            <Table.DataCell>
+                              <EndringstypeTag endringstype={endringstype} />
+                            </Table.DataCell>
+                            <Table.DataCell>
+                              {periode ? typeLabel(opptjeningstyper, periode.tjenesteType) : '–'}
+                            </Table.DataCell>
+                            <Table.DataCell>
+                              {periode?.periodeType ? typeLabel(opptjeningstyper, periode.periodeType) : '–'}
+                            </Table.DataCell>
+                            <Table.DataCell>{ft.tjenestestartDato ?? '–'}</Table.DataCell>
+                            <Table.DataCell>{ft.dimitteringDato ?? '–'}</Table.DataCell>
+                            <Table.DataCell>{ft.kilde ?? '–'}</Table.DataCell>
+                          </Table.Row>
+                        )
+                      })}
+                    </Table.Body>
+                  </Table>
+                </div>
+              )}
+            </VStack>
+          </>
+        ) : (
+          <BodyShort>Ingen endringer registrert.</BodyShort>
+        )}
+
+        <Form method="post">
+          <VStack gap="space-24">
+            <RadioGroup legend="Utfall" name="utfall" value={utfall} onChange={setUtfall}>
+              <Radio value="GODKJENN">Godkjenn</Radio>
+              <Radio value="IKKE_GODKJENN">Returner til saksbehandler</Radio>
+            </RadioGroup>
+
+            {utfall === 'IKKE_GODKJENN' && (
+              <RadioGroup
+                legend="Velg begrunnelse"
+                name="begrunnelse"
+                error={errors?.begrunnelse}
+                defaultValue={actionResultData?.begrunnelse}
+              >
+                <Radio size="small" value="Feil i vedtak">
+                  Feil i vedtak
+                </Radio>
+
+                <Radio size="small" value="Forvaltningsnotat utilstrekkelig">
+                  Forvaltningsnotat utilstrekkelig
+                </Radio>
+
+                <Radio size="small" value="Hent inn nytt grunnlag">
+                  Hent inn nytt grunnlag
+                </Radio>
+
+                <Radio size="small" value="Saksbehandlerstandard ikke fulgt">
+                  Saksbehandlerstandard ikke fulgt
+                </Radio>
+              </RadioGroup>
+            )}
+
+            <VStack gap="space-8" align="start">
+              <Button type="submit" variant="primary" size="small" loading={isSubmitting}>
+                Bekreft
+              </Button>
+              <Button type="button" variant="tertiary" size="small" onClick={avbrytAktivitet} disabled={isSubmitting}>
+                Avbryt behandling
+              </Button>
+            </VStack>
+          </VStack>
+        </Form>
+      </VStack>
+    </Page.Block>
+  )
+}

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
@@ -19,7 +19,6 @@ import { createAktivitetApi } from '~/api/aktivitet-api'
 import { createBehandlingApi } from '~/api/behandling-api'
 import { fetchOpptjeningstyper } from '~/api/opptjeningstyper-api.server'
 import styles from '~/common.module.css'
-import { userContext } from '~/context/user-context'
 import { useIsSubmitting } from '~/hooks/use-is-submitting'
 import type { AktivitetOutletContext } from '~/types/aktivitetOutletContext'
 import { formatCurrencyNok } from '~/utils/currency'
@@ -57,8 +56,7 @@ function EndringstypeTag({ endringstype }: { endringstype: Endringstype }) {
   )
 }
 
-export async function loader({ params, request, context }: Route.LoaderArgs) {
-  const { navident } = context.get(userContext)
+export async function loader({ params, request }: Route.LoaderArgs) {
   const { behandlingId, aktivitetId } = params
   const api = createAktivitetApi({ request, behandlingId, aktivitetId })
 
@@ -67,7 +65,7 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
     fetchOpptjeningstyper(request),
   ])
 
-  return { navident, grunnlag, opptjeningstyper }
+  return { grunnlag, opptjeningstyper }
 }
 
 enum AttesteringUtfall {
@@ -113,14 +111,13 @@ export async function action({ params, request }: Route.ActionArgs) {
   return data<AttesterActionData>({ errors: { utfall: 'Velg et utfall' } }, { status: 400 })
 }
 
-export default function AttesterRoute({ loaderData, actionData }: Route.ComponentProps) {
+export default function AttesterRoute({ actionData, loaderData }: Route.ComponentProps) {
   const { errors, data: actionResultData } = actionData || {}
   const { grunnlag, opptjeningstyper } = loaderData
   const { avbrytAktivitet } = useOutletContext<AktivitetOutletContext>()
   const isSubmitting = useIsSubmitting()
   const [utfall, setUtfall] = useState<string>('')
-
-  const vurdering = grunnlag.vurdering
+  const { vurdering } = grunnlag
 
   type InntektMedEndring = { endringstype: Endringstype; inntekt: InntektBackendDTO }
   type DagpengerMedEndring = { endringstype: Endringstype; dagpenger: DagpengerBackendDTO }

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/attester/index.tsx
@@ -86,6 +86,11 @@ enum AttesteringUtfall {
   IKKE_GODKJENN = 'IKKE_GODKJENN',
 }
 
+type AttesterActionData = {
+  errors?: { utfall?: string; begrunnelse?: string }
+  data?: { utfall: AttesteringUtfall; begrunnelse: string }
+}
+
 export async function action({ params, request }: Route.ActionArgs) {
   const { behandlingId } = params
   const behandlingApi = createBehandlingApi({ request, behandlingId })
@@ -103,7 +108,7 @@ export async function action({ params, request }: Route.ActionArgs) {
       await behandlingApi.returnerTilSaksbehandler(begrunnelse)
       return redirect(`/behandling/${behandlingId}/attestering-returnert-til-saksbehandler`)
     } else {
-      return data(
+      return data<AttesterActionData>(
         {
           errors: { begrunnelse: 'Begrunnelse må fylles ut' },
           data: {
@@ -116,7 +121,7 @@ export async function action({ params, request }: Route.ActionArgs) {
     }
   }
 
-  return data({ errors: { utfall: 'Velg et utfall' } }, { status: 400 })
+  return data<AttesterActionData>({ errors: { utfall: 'Velg et utfall' } }, { status: 400 })
 }
 
 export default function AttesterRoute({ loaderData, actionData }: Route.ComponentProps) {

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.test.ts
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.test.ts
@@ -1,0 +1,843 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { formatCurrencyNok } from '~/utils/currency'
+import type {
+  DagpengerBackendDTO,
+  ForstegangstjenesteBackendDTO,
+  InntektBackendDTO,
+  OmsorgBackendDTO,
+  OppdaterOpptjeningGrunnlag,
+  OpptjeningstyperResponse,
+  VurderingResponse,
+} from './oppdater-grunnlag-types'
+
+vi.mock('~/api/aktivitet-api', () => ({
+  createAktivitetApi: vi.fn(),
+}))
+vi.mock('~/api/opptjeningstyper-api.server', () => ({
+  fetchOpptjeningstyper: vi.fn(),
+}))
+
+const { createAktivitetApi } = await import('~/api/aktivitet-api')
+const { fetchOpptjeningstyper } = await import('~/api/opptjeningstyper-api.server')
+const {
+  action,
+  loader,
+  REQUIRED_KOMMUNE,
+  tilLinjeState,
+  beregnStatus,
+  nyInntektLinje,
+  nyDagpengerLinje,
+  nyForstegangstjenesteLinje,
+  typeLabel,
+  oversettKoderIMelding,
+  inntektEndringer,
+  dagpengerEndringer,
+  forstegangstjenesteEndringer,
+  toInntektBackend,
+  toDagpengerBackend,
+  toOmsorgBackend,
+  toForstegangstjenesteBackend,
+  inntektGrunnlagTilViewModel,
+  dagpengerGrunnlagTilViewModel,
+  omsorgGrunnlagTilViewModel,
+  forstegangstjenesteGrunnlagTilViewModel,
+  parseIsoDate,
+  toIsoDate,
+} = await import('./index')
+
+const opptjeningstyper: OpptjeningstyperResponse = {
+  inntekt: {
+    typer: [
+      { code: 'DIP_JSF', description: 'Utenlandsinntekt sjøfolk' },
+      { code: 'SVA_JSF', description: 'Svalbardinntekt sjøfolk' },
+      { code: 'SVA_PGI_LOENN', description: 'Svalbard PGI lønn' },
+      { code: 'SVA_PGI_LOENN_PD', description: 'Svalbard PGI lønn pensjonsdel' },
+      { code: 'INNTEKT_ANNET', description: 'Annen inntekt' },
+    ],
+    subTyper: [],
+  },
+  omsorg: {
+    typer: [{ code: 'OMS_BARN', description: 'Omsorg for barn' }],
+    subTyper: [],
+  },
+  dagpenger: {
+    typer: [
+      { code: 'DP', description: 'Ordinære dagpenger' },
+      { code: 'DP_FF', description: 'Dagpenger fiskere/fangstmenn' },
+    ],
+    subTyper: [],
+  },
+  forstegangstjeneste: {
+    typer: [{ code: 'MIL', description: 'Militærtjeneste' }],
+    subTyper: [{ code: 'FORSTE_6_MND', description: 'Første 6 måneder' }],
+  },
+}
+
+function fakeApi(overrides: Partial<Record<'hentGrunnlagsdata' | 'hentVurdering' | 'lagreVurdering', unknown>> = {}) {
+  return {
+    hentGrunnlagsdata: vi.fn().mockResolvedValue({}),
+    hentVurdering: vi.fn().mockResolvedValue(null),
+    lagreVurdering: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+function requestMedFormData(fields: Record<string, string>): Request {
+  const formData = new FormData()
+  for (const [key, value] of Object.entries(fields)) {
+    formData.set(key, value)
+  }
+  return new Request('http://localhost/aktivitet', { method: 'POST', body: formData })
+}
+
+function assertDataResult(result: Awaited<ReturnType<typeof action>>) {
+  if (result instanceof Response) {
+    throw new Error('Forventet data()-resultat, fikk Response (redirect)')
+  }
+  return result
+}
+
+beforeEach(() => {
+  vi.mocked(createAktivitetApi).mockReset()
+  vi.mocked(fetchOpptjeningstyper).mockReset().mockResolvedValue(opptjeningstyper)
+})
+
+describe('typeLabel', () => {
+  it('returns description for known inntekt code', () => {
+    expect(typeLabel(opptjeningstyper, 'DIP_JSF')).toBe('Utenlandsinntekt sjøfolk')
+  })
+
+  it('returns description for known subtype code', () => {
+    expect(typeLabel(opptjeningstyper, 'FORSTE_6_MND')).toBe('Første 6 måneder')
+  })
+
+  it('returns the code itself when unknown', () => {
+    expect(typeLabel(opptjeningstyper, 'UKJENT_KODE')).toBe('UKJENT_KODE')
+  })
+})
+
+describe('oversettKoderIMelding', () => {
+  it('replaces a single known code embedded in a sentence', () => {
+    const resultat = oversettKoderIMelding('Skattekommune for DIP_JSF må være 0301', opptjeningstyper)
+    expect(resultat).toBe('Skattekommune for Utenlandsinntekt sjøfolk (DIP_JSF) må være 0301')
+  })
+
+  it('replaces multiple distinct codes in the same message', () => {
+    const resultat = oversettKoderIMelding('Feil for DIP_JSF og SVA_JSF', opptjeningstyper)
+    expect(resultat).toBe('Feil for Utenlandsinntekt sjøfolk (DIP_JSF) og Svalbardinntekt sjøfolk (SVA_JSF)')
+  })
+
+  it('prefers the longest matching code over an overlapping prefix', () => {
+    const resultat = oversettKoderIMelding('Ugyldig type SVA_PGI_LOENN_PD', opptjeningstyper)
+    expect(resultat).toBe('Ugyldig type Svalbard PGI lønn pensjonsdel (SVA_PGI_LOENN_PD)')
+  })
+
+  it('does not replace a code that is part of a larger word', () => {
+    const resultat = oversettKoderIMelding('Ukjent verdi SVA_JSF2', opptjeningstyper)
+    expect(resultat).toBe('Ukjent verdi SVA_JSF2')
+  })
+
+  it('returns the message unchanged when no known codes are present', () => {
+    const resultat = oversettKoderIMelding('Generell feilmelding uten koder', opptjeningstyper)
+    expect(resultat).toBe('Generell feilmelding uten koder')
+  })
+})
+
+describe('nyInntektLinje', () => {
+  it('prefylles kommune fra REQUIRED_KOMMUNE når typen krever det', () => {
+    const linje = nyInntektLinje('DIP_JSF')
+    expect(linje.kommune).toBe(REQUIRED_KOMMUNE.DIP_JSF)
+    expect(linje._status).toBe('new')
+    expect(linje._original).toBeNull()
+  })
+
+  it('setter kommune til null når typen ikke krever en spesifikk kommune', () => {
+    const linje = nyInntektLinje('INNTEKT_ANNET')
+    expect(linje.kommune).toBeNull()
+  })
+})
+
+describe('nyDagpengerLinje', () => {
+  it('returnerer forventede standardverdier', () => {
+    const linje = nyDagpengerLinje()
+    expect(linje.dagpengerType).toBe('DP')
+    expect(linje.ar).toBe(new Date().getFullYear())
+    expect(linje.uavkortetDagpengegrunnlag).toBeNull()
+    expect(linje.utbetalteDagpenger).toBeNull()
+    expect(linje.ferietillegg).toBeNull()
+    expect(linje.barnetillegg).toBeNull()
+    expect(linje._status).toBe('new')
+  })
+})
+
+describe('nyForstegangstjenesteLinje', () => {
+  it('returnerer forventede standardverdier', () => {
+    const linje = nyForstegangstjenesteLinje()
+    expect(linje.tjenesteType).toBe('MIL')
+    expect(linje.periodeType).toBeNull()
+    expect(linje.fomDato).toBe('')
+    expect(linje.tomDato).toBe('')
+    expect(linje._status).toBe('new')
+  })
+})
+
+describe('tilLinjeState', () => {
+  it('setter status original og en uavhengig kopi som _original', () => {
+    const dto = { inntektAr: 2020, inntektType: 'DIP_JSF', belop: 100, kommune: '0301' }
+    const linje = tilLinjeState(dto)
+
+    expect(linje._status).toBe('original')
+    expect(linje._original).toEqual(dto)
+    expect(linje._original).not.toBe(dto)
+
+    linje.belop = 200
+    expect(linje._original?.belop).toBe(100)
+  })
+})
+
+describe('beregnStatus', () => {
+  type TestFelt = { a: number; b: string }
+  const felter: (keyof TestFelt)[] = ['a', 'b']
+
+  it('beholder new-status uavhengig av feltendringer', () => {
+    const linje = { a: 1, b: 'x', _status: 'new' as const, _original: null }
+    expect(beregnStatus<TestFelt>(linje, felter)).toBe('new')
+  })
+
+  it('beholder deleted-status uavhengig av feltendringer', () => {
+    const linje = { a: 1, b: 'x', _status: 'deleted' as const, _original: { a: 1, b: 'x' } }
+    expect(beregnStatus<TestFelt>(linje, felter)).toBe('deleted')
+  })
+
+  it('returnerer new når _original mangler', () => {
+    const linje = { a: 1, b: 'x', _status: 'original' as const, _original: null }
+    expect(beregnStatus<TestFelt>(linje, felter)).toBe('new')
+  })
+
+  it('returnerer modified når et sporet felt avviker fra original', () => {
+    const linje = { a: 2, b: 'x', _status: 'original' as const, _original: { a: 1, b: 'x' } }
+    expect(beregnStatus<TestFelt>(linje, felter)).toBe('modified')
+  })
+
+  it('returnerer original når ingen sporede felt avviker', () => {
+    const linje = { a: 1, b: 'x', _status: 'modified' as const, _original: { a: 1, b: 'x' } }
+    expect(beregnStatus<TestFelt>(linje, felter)).toBe('original')
+  })
+})
+
+describe('inntektEndringer', () => {
+  it('returnerer tom liste når linjen ikke har original', () => {
+    const linje = tilLinjeState({ inntektAr: 2020, inntektType: 'DIP_JSF', belop: 100, kommune: '0301' })
+    expect(inntektEndringer({ ...linje, _original: null }, opptjeningstyper)).toEqual([])
+  })
+
+  it('rapporterer endring i inntektstype, år, beløp og kommune', () => {
+    const original = { inntektAr: 2020, inntektType: 'DIP_JSF', belop: 100, kommune: '0301' }
+    const linje = { ...tilLinjeState(original), inntektType: 'SVA_JSF', inntektAr: 2021, belop: 200, kommune: '2100' }
+
+    const resultat = inntektEndringer(linje, opptjeningstyper)
+
+    expect(resultat).toContain('Inntektstype: Utenlandsinntekt sjøfolk → Svalbardinntekt sjøfolk')
+    expect(resultat).toContain('År: 2020 → 2021')
+    expect(resultat).toContain(`Beløp: ${formatCurrencyNok(100)} → ${formatCurrencyNok(200)}`)
+    expect(resultat).toContain('Skattekommune: 0301 → 2100')
+  })
+
+  it('viser – når beløp går fra verdi til null', () => {
+    const original = { inntektAr: 2020, inntektType: 'DIP_JSF', belop: 100, kommune: '0301' }
+    const linje = { ...tilLinjeState(original), belop: null }
+
+    expect(inntektEndringer(linje, opptjeningstyper)).toContain(`Beløp: ${formatCurrencyNok(100)} → –`)
+  })
+})
+
+describe('dagpengerEndringer', () => {
+  it('ekskluderer uavkortet grunnlag og ferietillegg for DP_FF', () => {
+    const original = {
+      ar: 2020,
+      dagpengerType: 'DP_FF',
+      uavkortetDagpengegrunnlag: 100,
+      utbetalteDagpenger: 50,
+      ferietillegg: 10,
+      barnetillegg: 5,
+    }
+    const linje = { ...tilLinjeState(original), uavkortetDagpengegrunnlag: 999, ferietillegg: 999 }
+
+    const resultat = dagpengerEndringer(linje, opptjeningstyper)
+
+    expect(resultat.some(e => e.startsWith('Uavkortet grunnlag'))).toBe(false)
+    expect(resultat.some(e => e.startsWith('Ferietillegg'))).toBe(false)
+  })
+
+  it('inkluderer uavkortet grunnlag og ferietillegg for andre typer enn DP_FF', () => {
+    const original = {
+      ar: 2020,
+      dagpengerType: 'DP',
+      uavkortetDagpengegrunnlag: 100,
+      utbetalteDagpenger: 50,
+      ferietillegg: 10,
+      barnetillegg: 5,
+    }
+    const linje = { ...tilLinjeState(original), uavkortetDagpengegrunnlag: 200, ferietillegg: 20 }
+
+    const resultat = dagpengerEndringer(linje, opptjeningstyper)
+
+    expect(resultat).toContain(`Uavkortet grunnlag: ${formatCurrencyNok(100)} → ${formatCurrencyNok(200)}`)
+    expect(resultat).toContain(`Ferietillegg: ${formatCurrencyNok(10)} → ${formatCurrencyNok(20)}`)
+  })
+})
+
+describe('forstegangstjenesteEndringer', () => {
+  it('rapporterer endring i type, periodetype, fom og tom', () => {
+    const original = { tjenesteType: 'MIL', periodeType: null, fomDato: '2010-01-01', tomDato: '2010-06-01' }
+    const linje = {
+      ...tilLinjeState(original),
+      periodeType: 'FORSTE_6_MND',
+      fomDato: '2010-02-01',
+      tomDato: '2010-07-01',
+    }
+
+    const resultat = forstegangstjenesteEndringer(linje, opptjeningstyper)
+
+    expect(resultat).toContain('Periodetype: – → Første 6 måneder')
+    expect(resultat).toContain('FOM: 2010-01-01 → 2010-02-01')
+    expect(resultat).toContain('TOM: 2010-06-01 → 2010-07-01')
+  })
+})
+
+describe('toInntektBackend', () => {
+  it('mapper linjen til backend-DTO med kilde PEN', () => {
+    const linje = tilLinjeState({ inntektAr: 2020, inntektType: 'DIP_JSF', belop: 100, kommune: '0301' })
+
+    expect(toInntektBackend(linje, '12345678901')).toEqual({
+      inntektId: null,
+      fnr: '12345678901',
+      kilde: 'PEN',
+      kommune: '0301',
+      piMerke: null,
+      inntektAr: 2020,
+      belop: '100',
+      inntektType: 'DIP_JSF',
+    })
+  })
+})
+
+describe('toDagpengerBackend', () => {
+  it('nuller uavkortet grunnlag og ferietillegg for DP_FF', () => {
+    const linje = tilLinjeState({
+      ar: 2020,
+      dagpengerType: 'DP_FF',
+      uavkortetDagpengegrunnlag: 100,
+      utbetalteDagpenger: 50,
+      ferietillegg: 10,
+      barnetillegg: 5,
+    })
+
+    const backend = toDagpengerBackend(linje, '12345678901')
+
+    expect(backend.uavkortetDagpengegrunnlag).toBeNull()
+    expect(backend.ferietillegg).toBeNull()
+    expect(backend.utbetalteDagpenger).toBe(50)
+    expect(backend.barnetillegg).toBe(5)
+  })
+
+  it('beholder verdier for andre dagpengetyper', () => {
+    const linje = tilLinjeState({
+      ar: 2020,
+      dagpengerType: 'DP',
+      uavkortetDagpengegrunnlag: 100,
+      utbetalteDagpenger: 50,
+      ferietillegg: 10,
+      barnetillegg: 5,
+    })
+
+    const backend = toDagpengerBackend(linje, '12345678901')
+
+    expect(backend.uavkortetDagpengegrunnlag).toBe(100)
+    expect(backend.ferietillegg).toBe(10)
+  })
+})
+
+describe('toOmsorgBackend', () => {
+  it('mapper linjen til backend-DTO', () => {
+    const linje = tilLinjeState({ ar: 2020, omsorgType: 'OMS_BARN', fnrOmsorgFor: '10987654321' })
+
+    expect(toOmsorgBackend(linje, '12345678901')).toEqual({
+      omsorgId: null,
+      fnr: '12345678901',
+      fnrOmsorgFor: '10987654321',
+      omsorgType: 'OMS_BARN',
+      kilde: 'PEN',
+      ar: 2020,
+    })
+  })
+})
+
+describe('toForstegangstjenesteBackend', () => {
+  it('bygger en periodeliste med ett element fra linjen', () => {
+    const linje = tilLinjeState({
+      tjenesteType: 'MIL',
+      periodeType: 'FORSTE_6_MND',
+      fomDato: '2010-01-01',
+      tomDato: '2010-06-01',
+    })
+
+    const backend = toForstegangstjenesteBackend(linje, '12345678901')
+
+    expect(backend.tjenestestartDato).toBe('2010-01-01')
+    expect(backend.dimitteringDato).toBe('2010-06-01')
+    expect(backend.forstegangstjenestePeriodeListe).toEqual([
+      {
+        forstegangstjenestePeriodeId: null,
+        periodeType: 'FORSTE_6_MND',
+        tjenesteType: 'MIL',
+        fomDato: '2010-01-01',
+        tomDato: '2010-06-01',
+      },
+    ])
+  })
+
+  it('bruker null for tomme datoer', () => {
+    const linje = tilLinjeState({ tjenesteType: 'MIL', periodeType: null, fomDato: '', tomDato: '' })
+    const backend = toForstegangstjenesteBackend(linje, '12345678901')
+
+    expect(backend.tjenestestartDato).toBeNull()
+    expect(backend.dimitteringDato).toBeNull()
+  })
+})
+
+describe('inntektGrunnlagTilViewModel', () => {
+  it('konverterer belop fra streng til tall', () => {
+    const dto: InntektBackendDTO = {
+      inntektId: 1,
+      fnr: '12345678901',
+      kommune: '0301',
+      inntektAr: 2020,
+      belop: '1234',
+      inntektType: 'DIP_JSF',
+    }
+
+    expect(inntektGrunnlagTilViewModel(dto)).toEqual({
+      inntektId: 1,
+      kommune: '0301',
+      inntektAr: 2020,
+      belop: 1234,
+      inntektType: 'DIP_JSF',
+    })
+  })
+})
+
+describe('dagpengerGrunnlagTilViewModel', () => {
+  it('mapper felter med fallback for manglende verdier', () => {
+    const dto = { fnr: '12345678901', dagpengerType: 'DP' } as unknown as DagpengerBackendDTO
+
+    expect(dagpengerGrunnlagTilViewModel(dto)).toEqual({
+      dagpengerId: null,
+      ar: 0,
+      dagpengerType: 'DP',
+      uavkortetDagpengegrunnlag: null,
+      utbetalteDagpenger: null,
+      ferietillegg: null,
+      barnetillegg: null,
+    })
+  })
+})
+
+describe('omsorgGrunnlagTilViewModel', () => {
+  it('mapper felter', () => {
+    const dto: OmsorgBackendDTO = { fnr: '12345678901', omsorgType: 'OMS_BARN', ar: 2020, fnrOmsorgFor: '999' }
+
+    expect(omsorgGrunnlagTilViewModel(dto)).toEqual({
+      omsorgId: null,
+      ar: 2020,
+      omsorgType: 'OMS_BARN',
+      fnrOmsorgFor: '999',
+    })
+  })
+})
+
+describe('forstegangstjenesteGrunnlagTilViewModel', () => {
+  it('returnerer tom liste når dto mangler', () => {
+    expect(forstegangstjenesteGrunnlagTilViewModel(null)).toEqual([])
+    expect(forstegangstjenesteGrunnlagTilViewModel(undefined)).toEqual([])
+  })
+
+  it('mapper periodelisten til flate DTO-er', () => {
+    const dto: ForstegangstjenesteBackendDTO = {
+      forstegangstjenesteId: 42,
+      fnr: '12345678901',
+      forstegangstjenestePeriodeListe: [
+        { tjenesteType: 'MIL', periodeType: 'FORSTE_6_MND', fomDato: '2010-01-01', tomDato: '2010-06-01' },
+      ],
+    }
+
+    expect(forstegangstjenesteGrunnlagTilViewModel(dto)).toEqual([
+      {
+        forstegangstjenesteId: 42,
+        tjenesteType: 'MIL',
+        periodeType: 'FORSTE_6_MND',
+        fomDato: '2010-01-01',
+        tomDato: '2010-06-01',
+      },
+    ])
+  })
+})
+
+describe('parseIsoDate / toIsoDate', () => {
+  it('parser en gyldig ISO-dato', () => {
+    const dato = parseIsoDate('2024-03-05')
+    expect(dato?.getFullYear()).toBe(2024)
+    expect(dato?.getMonth()).toBe(2)
+    expect(dato?.getDate()).toBe(5)
+  })
+
+  it('returnerer undefined for ugyldig dato', () => {
+    expect(parseIsoDate('')).toBeUndefined()
+    expect(parseIsoDate('2024-03')).toBeUndefined()
+  })
+
+  it('formaterer en dato tilbake til ISO-format med nullutfylling', () => {
+    expect(toIsoDate(new Date(2024, 2, 5))).toBe('2024-03-05')
+  })
+
+  it('rundtrip parseIsoDate → toIsoDate gir samme verdi', () => {
+    const iso = '2024-03-05'
+    expect(toIsoDate(parseIsoDate(iso) as Date)).toBe(iso)
+  })
+})
+
+describe('loader', () => {
+  it('henter grunnlag, vurdering og opptjeningstyper (happy path)', async () => {
+    const grunnlag: OppdaterOpptjeningGrunnlag = {
+      saker: [],
+      opptjeningsGrunnlagDto: { fnr: '123', inntektListe: [], omsorgListe: [], dagpengerListe: [] },
+    }
+    const vurderingResponse: VurderingResponse = { vurdering: JSON.stringify({ fnr: '123' }) }
+    const api = fakeApi({
+      hentGrunnlagsdata: vi.fn().mockResolvedValue(grunnlag),
+      hentVurdering: vi.fn().mockResolvedValue(vurderingResponse),
+    })
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = await loader({
+      params: { behandlingId: '1', aktivitetId: '2' },
+      request: new Request('http://localhost/aktivitet'),
+    } as never)
+
+    expect(result.grunnlag).toBe(grunnlag)
+    expect(result.savedVurdering).toEqual({ fnr: '123' })
+    expect(result.opptjeningstyper).toBe(opptjeningstyper)
+    expect(result.readOnly).toBe(false)
+  })
+
+  it('setter readOnly når hentGrunnlagsdata feiler med 403', async () => {
+    const api = fakeApi({
+      hentGrunnlagsdata: vi.fn().mockRejectedValue({ data: { status: 403, title: 'Forbidden' } }),
+    })
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = await loader({
+      params: { behandlingId: '1', aktivitetId: '2' },
+      request: new Request('http://localhost/aktivitet'),
+    } as never)
+
+    expect(result.readOnly).toBe(true)
+    expect(result.grunnlag).toEqual({})
+  })
+
+  it('kaster videre feil som ikke er 403', async () => {
+    const api = fakeApi({
+      hentGrunnlagsdata: vi.fn().mockRejectedValue({ data: { status: 500, title: 'Server error' } }),
+    })
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    await expect(
+      loader({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: new Request('http://localhost/aktivitet'),
+      } as never),
+    ).rejects.toBeDefined()
+  })
+
+  it('returnerer savedVurdering null når det ikke finnes en lagret vurdering', async () => {
+    const api = fakeApi({ hentVurdering: vi.fn().mockResolvedValue(null) })
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = await loader({
+      params: { behandlingId: '1', aktivitetId: '2' },
+      request: new Request('http://localhost/aktivitet'),
+    } as never)
+
+    expect(result.savedVurdering).toBeNull()
+  })
+})
+
+describe('action', () => {
+  it('returnerer _form-feil når payload mangler', async () => {
+    const api = fakeApi()
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = assertDataResult(
+      await action({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: requestMedFormData({}),
+      } as never),
+    )
+
+    expect(result.data.errors._form).toBe('Mangler skjemadata')
+    expect(result.init?.status).toBe(400)
+  })
+
+  it('returnerer _form-feil når payload ikke er gyldig JSON', async () => {
+    const api = fakeApi()
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = assertDataResult(
+      await action({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: requestMedFormData({ payload: 'ikke-json{' }),
+      } as never),
+    )
+
+    expect(result.data.errors._form).toBe('Ugyldig skjemadata')
+    expect(result.init?.status).toBe(400)
+  })
+
+  it('returnerer valideringsfeil når skattekommune ikke matcher kravet', async () => {
+    const api = fakeApi()
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const payload = {
+      inntektEndringer: [
+        {
+          endringstype: 'OPPRETT',
+          inntektListe: [{ inntektType: 'DIP_JSF', kommune: '9999', inntektAr: 2020, belop: '100' }],
+        },
+      ],
+    }
+
+    const result = assertDataResult(
+      await action({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: requestMedFormData({ payload: JSON.stringify(payload) }),
+      } as never),
+    )
+
+    expect(result.data.errors._form).toContain('Skattekommune for DIP_JSF må være 0301')
+    expect(result.init?.status).toBe(400)
+    expect(api.lagreVurdering).not.toHaveBeenCalled()
+  })
+
+  it('hopper over kommune-validering for slettede linjer', async () => {
+    const api = fakeApi()
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const payload = {
+      inntektEndringer: [
+        {
+          endringstype: 'SLETT',
+          inntektListe: [{ inntektType: 'DIP_JSF', kommune: '9999', inntektAr: 2020, belop: '100' }],
+        },
+      ],
+    }
+
+    const result = await action({
+      params: { behandlingId: '1', aktivitetId: '2' },
+      request: requestMedFormData({ payload: JSON.stringify(payload) }),
+    } as never)
+
+    expect(result).toBeInstanceOf(Response)
+    expect(api.lagreVurdering).toHaveBeenCalled()
+  })
+
+  it('returnerer valideringsfeil når tjenestestartdato er før 2010-01-01', async () => {
+    const api = fakeApi()
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const payload = {
+      forstegangstjenesteEndringer: [
+        {
+          endringstype: 'OPPRETT',
+          forstegangstjeneste: { tjenestestartDato: '2005-01-01', forstegangstjenestePeriodeListe: [] },
+        },
+      ],
+    }
+
+    const result = assertDataResult(
+      await action({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: requestMedFormData({ payload: JSON.stringify(payload) }),
+      } as never),
+    )
+
+    expect(result.data.errors._form).toContain('Tjenestestartdato for førstegangstjeneste kan ikke være før 01.01.2010')
+  })
+
+  it('slår sammen flere valideringsfeil med punktum', async () => {
+    const api = fakeApi()
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const payload = {
+      inntektEndringer: [
+        {
+          endringstype: 'OPPRETT',
+          inntektListe: [{ inntektType: 'DIP_JSF', kommune: '9999', inntektAr: 2020, belop: '100' }],
+        },
+      ],
+      forstegangstjenesteEndringer: [
+        {
+          endringstype: 'OPPRETT',
+          forstegangstjeneste: { tjenestestartDato: '2005-01-01', forstegangstjenestePeriodeListe: [] },
+        },
+      ],
+    }
+
+    const result = assertDataResult(
+      await action({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: requestMedFormData({ payload: JSON.stringify(payload) }),
+      } as never),
+    )
+
+    expect(result.data.errors._form).toBe(
+      'Skattekommune for DIP_JSF må være 0301. Tjenestestartdato for førstegangstjeneste kan ikke være før 01.01.2010',
+    )
+  })
+
+  it('nuller uavkortet grunnlag og ferietillegg for DP_FF før lagring', async () => {
+    const api = fakeApi()
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const payload = {
+      dagpengerEndringer: [
+        {
+          endringstype: 'OPPRETT',
+          dagpengerListe: [
+            {
+              dagpengerType: 'DP_FF',
+              ar: 2020,
+              uavkortetDagpengegrunnlag: 100,
+              ferietillegg: 10,
+              utbetalteDagpenger: 50,
+            },
+          ],
+        },
+      ],
+    }
+
+    await action({
+      params: { behandlingId: '1', aktivitetId: '2' },
+      request: requestMedFormData({ payload: JSON.stringify(payload) }),
+    } as never)
+
+    expect(api.lagreVurdering).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dagpengerEndringer: [
+          expect.objectContaining({
+            dagpengerListe: [
+              expect.objectContaining({
+                uavkortetDagpengegrunnlag: null,
+                ferietillegg: null,
+                utbetalteDagpenger: 50,
+              }),
+            ],
+          }),
+        ],
+      }),
+    )
+  })
+
+  it('inkluderer sakId i vurderingen når det er sendt inn', async () => {
+    const api = fakeApi()
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    await action({
+      params: { behandlingId: '1', aktivitetId: '2' },
+      request: requestMedFormData({ payload: JSON.stringify({}), sakId: '999' }),
+    } as never)
+
+    expect(api.lagreVurdering).toHaveBeenCalledWith(expect.objectContaining({ sakId: 999 }))
+  })
+
+  it('redirecter til behandlingssiden etter vellykket lagring', async () => {
+    const api = fakeApi()
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = await action({
+      params: { behandlingId: '1', aktivitetId: '2' },
+      request: requestMedFormData({ payload: JSON.stringify({}) }),
+    } as never)
+
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(302)
+    expect((result as Response).headers.get('Location')).toBe('/behandling/1?justCompleted=2')
+  })
+
+  it('returnerer violations fra backend som _server-feil ved 400', async () => {
+    const api = fakeApi({
+      lagreVurdering: vi
+        .fn()
+        .mockRejectedValue({ data: { status: 400, title: 'Bad request', violations: ['Feil A', 'Feil B'] } }),
+    })
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = assertDataResult(
+      await action({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: requestMedFormData({ payload: JSON.stringify({}) }),
+      } as never),
+    )
+
+    expect(result.data.errors._server).toEqual(['Feil A', 'Feil B'])
+    expect(result.init?.status).toBe(400)
+  })
+
+  it('faller tilbake til error.data.message når violations mangler', async () => {
+    const api = fakeApi({
+      lagreVurdering: vi
+        .fn()
+        .mockRejectedValue({ data: { status: 400, title: 'Bad request', message: 'Noe gikk galt' } }),
+    })
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = assertDataResult(
+      await action({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: requestMedFormData({ payload: JSON.stringify({}) }),
+      } as never),
+    )
+
+    expect(result.data.errors._server).toEqual(['Noe gikk galt'])
+  })
+
+  it('faller tilbake til generisk melding når verken violations eller message finnes', async () => {
+    const api = fakeApi({
+      lagreVurdering: vi.fn().mockRejectedValue({ data: { status: 400, title: 'Bad request' } }),
+    })
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = assertDataResult(
+      await action({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: requestMedFormData({ payload: JSON.stringify({}) }),
+      } as never),
+    )
+
+    expect(result.data.errors._server).toEqual(['POPP-validering feilet'])
+  })
+
+  it('returnerer generisk _server-feil ved ikke-400-feil', async () => {
+    const api = fakeApi({ lagreVurdering: vi.fn().mockRejectedValue(new Error('Nettverksfeil')) })
+    vi.mocked(createAktivitetApi).mockReturnValue(api as never)
+
+    const result = assertDataResult(
+      await action({
+        params: { behandlingId: '1', aktivitetId: '2' },
+        request: requestMedFormData({ payload: JSON.stringify({}) }),
+      } as never),
+    )
+
+    expect(result.data.errors._server).toEqual(['Det oppstod en feil ved lagring'])
+    expect(result.init?.status).toBe(500)
+  })
+})

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.test.ts
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.test.ts
@@ -7,7 +7,6 @@ import type {
   OmsorgBackendDTO,
   OppdaterOpptjeningGrunnlag,
   OpptjeningstyperResponse,
-  VurderingResponse,
 } from './oppdater-grunnlag-types'
 
 vi.mock('~/api/aktivitet-api', () => ({
@@ -73,10 +72,9 @@ const opptjeningstyper: OpptjeningstyperResponse = {
   },
 }
 
-function fakeApi(overrides: Partial<Record<'hentGrunnlagsdata' | 'hentVurdering' | 'lagreVurdering', unknown>> = {}) {
+function fakeApi(overrides: Partial<Record<'hentGrunnlagsdata' | 'lagreVurdering', unknown>> = {}) {
   return {
     hentGrunnlagsdata: vi.fn().mockResolvedValue({}),
-    hentVurdering: vi.fn().mockResolvedValue(null),
     lagreVurdering: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   }
@@ -507,15 +505,13 @@ describe('parseIsoDate / toIsoDate', () => {
 })
 
 describe('loader', () => {
-  it('henter grunnlag, vurdering og opptjeningstyper (happy path)', async () => {
+  it('henter grunnlag og opptjeningstyper (happy path)', async () => {
     const grunnlag: OppdaterOpptjeningGrunnlag = {
       saker: [],
       opptjeningsGrunnlagDto: { fnr: '123', inntektListe: [], omsorgListe: [], dagpengerListe: [] },
     }
-    const vurderingResponse: VurderingResponse = { vurdering: JSON.stringify({ fnr: '123' }) }
     const api = fakeApi({
       hentGrunnlagsdata: vi.fn().mockResolvedValue(grunnlag),
-      hentVurdering: vi.fn().mockResolvedValue(vurderingResponse),
     })
     vi.mocked(createAktivitetApi).mockReturnValue(api as never)
 
@@ -525,7 +521,6 @@ describe('loader', () => {
     } as never)
 
     expect(result.grunnlag).toBe(grunnlag)
-    expect(result.savedVurdering).toEqual({ fnr: '123' })
     expect(result.opptjeningstyper).toBe(opptjeningstyper)
     expect(result.readOnly).toBe(false)
   })
@@ -560,7 +555,7 @@ describe('loader', () => {
   })
 
   it('returnerer savedVurdering null når det ikke finnes en lagret vurdering', async () => {
-    const api = fakeApi({ hentVurdering: vi.fn().mockResolvedValue(null) })
+    const api = fakeApi()
     vi.mocked(createAktivitetApi).mockReturnValue(api as never)
 
     const result = await loader({
@@ -568,7 +563,7 @@ describe('loader', () => {
       request: new Request('http://localhost/aktivitet'),
     } as never)
 
-    expect(result.savedVurdering).toBeNull()
+    expect(result.opptjeningstyper).toBe(opptjeningstyper)
   })
 })
 

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
@@ -1,0 +1,1697 @@
+import { InformationSquareIcon, PlusIcon, TrashIcon } from '@navikt/aksel-icons'
+import {
+  BodyShort,
+  Box,
+  Button,
+  DatePicker,
+  Heading,
+  HStack,
+  InfoCard,
+  InlineMessage,
+  LocalAlert,
+  Page,
+  Select,
+  Table,
+  Tag,
+  TextField,
+  useDatepicker,
+  VStack,
+} from '@navikt/ds-react'
+import { useMemo, useState } from 'react'
+import { data, Form, redirect, useOutletContext } from 'react-router'
+import { createAktivitetApi } from '~/api/aktivitet-api'
+import { isApiError } from '~/api/error.types'
+import { fetchOpptjeningstyper } from '~/api/opptjeningstyper-api.server'
+import styles from '~/common.module.css'
+import { Fnr } from '~/components/Fnr'
+import { useIsSubmitting } from '~/hooks/use-is-submitting'
+import type { AktivitetOutletContext } from '~/types/aktivitetOutletContext'
+import { formatCurrencyNok } from '~/utils/currency'
+import type { Route } from './+types'
+import type {
+  DagpengerBackendDTO,
+  DagpengerDTO,
+  ForstegangstjenesteBackendDTO,
+  ForstegangstjenesteDTO,
+  InntektBackendDTO,
+  InntektDTO,
+  OmsorgBackendDTO,
+  OmsorgDTO,
+  OppdaterOpptjeningGrunnlag,
+  OppdaterOpptjeningVurdering,
+  OpptjeningstyperResponse,
+  VurderingResponse,
+} from './oppdater-grunnlag-types'
+
+export function meta() {
+  return [{ title: 'Oppdater opptjeningsgrunnlag' }]
+}
+
+const KILDE = 'PEN'
+
+export const REQUIRED_KOMMUNE: Partial<Record<string, string>> = {
+  DIP_JSF: '0301',
+  DIP_LON: '0301',
+  DIP_SEL: '0301',
+  SJO_JSF: '2312',
+  SJO_LON: '2312',
+  SJO_SEL: '2312',
+  SVA_JSF: '2100',
+  SVA_LON: '2100',
+  SVA_SEL: '2100',
+  SVA_PGI_LOENN: '2100',
+  SVA_PGI_LOENN_PD: '2100',
+  SVA_PGI_NAERING: '2100',
+  SVA_PGI_NAERING_FFF: '2100',
+  UTE_JSF: '2101',
+  UTE_LON: '2101',
+  UTE_SEL: '2101',
+}
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const { behandlingId, aktivitetId } = params
+  const api = createAktivitetApi({ request, behandlingId, aktivitetId })
+
+  let grunnlag: OppdaterOpptjeningGrunnlag = {}
+  let readOnly = false
+
+  try {
+    grunnlag = (await api.hentGrunnlagsdata<OppdaterOpptjeningGrunnlag>()) ?? {}
+  } catch (error) {
+    if (isApiError(error) && error.data.status === 403) {
+      readOnly = true
+    } else {
+      throw error
+    }
+  }
+
+  const [vurderingResponse, opptjeningstyper] = await Promise.all([
+    api.hentVurdering<VurderingResponse>(),
+    fetchOpptjeningstyper(request),
+  ])
+
+  const savedVurdering: OppdaterOpptjeningVurdering | null = vurderingResponse?.vurdering
+    ? (JSON.parse(vurderingResponse.vurdering) as OppdaterOpptjeningVurdering)
+    : null
+
+  return { grunnlag, savedVurdering, opptjeningstyper, readOnly }
+}
+
+export type ActionErrors = { _form?: string; _server?: string[] }
+
+export async function action({ params, request }: Route.ActionArgs) {
+  const { behandlingId, aktivitetId } = params
+  const api = createAktivitetApi({ request, behandlingId, aktivitetId })
+
+  const formData = await request.formData()
+  const sakIdRaw = formData.get('sakId')
+  const payloadRaw = formData.get('payload')
+
+  if (!payloadRaw) {
+    return data({ errors: { _form: 'Mangler skjemadata' } as ActionErrors }, { status: 400 })
+  }
+
+  let payload: OppdaterOpptjeningVurdering
+
+  try {
+    payload = JSON.parse(payloadRaw as string)
+  } catch {
+    return data({ errors: { _form: 'Ugyldig skjemadata' } as ActionErrors }, { status: 400 })
+  }
+
+  const validationErrors: string[] = []
+
+  const alleInntekter = (payload.inntektEndringer ?? [])
+    .filter(e => e.endringstype !== 'SLETT')
+    .flatMap(e => e.inntektListe)
+  for (const inntekt of alleInntekter) {
+    const required = REQUIRED_KOMMUNE[inntekt.inntektType]
+    if (required && inntekt.kommune?.trim() !== required) {
+      validationErrors.push(`Skattekommune for ${inntekt.inntektType} må være ${required}`)
+    }
+  }
+
+  const alleFt = (payload.forstegangstjenesteEndringer ?? [])
+    .filter(e => e.endringstype !== 'SLETT')
+    .map(e => e.forstegangstjeneste)
+  for (const ft of alleFt) {
+    if (ft.tjenestestartDato && ft.tjenestestartDato < '2010-01-01') {
+      validationErrors.push('Tjenestestartdato for førstegangstjeneste kan ikke være før 01.01.2010')
+    }
+  }
+
+  if (validationErrors.length > 0) {
+    return data({ errors: { _form: validationErrors.join('. ') } as ActionErrors }, { status: 400 })
+  }
+
+  payload.dagpengerEndringer = (payload.dagpengerEndringer ?? []).map(e => ({
+    ...e,
+    dagpengerListe: e.dagpengerListe.map(d =>
+      d.dagpengerType === 'DP_FF' ? { ...d, uavkortetDagpengegrunnlag: null, ferietillegg: null } : d,
+    ),
+  }))
+
+  const vurdering: OppdaterOpptjeningVurdering = {
+    ...(sakIdRaw ? { sakId: Number(sakIdRaw) } : {}),
+    ...payload,
+  }
+
+  try {
+    await api.lagreVurdering(vurdering)
+    return redirect(`/behandling/${behandlingId}?justCompleted=${aktivitetId}`)
+  } catch (error) {
+    if (isApiError(error) && error.data.status === 400) {
+      const meldinger = error.data.violations?.length
+        ? error.data.violations
+        : [error.data.message ?? 'POPP-validering feilet']
+      return data({ errors: { _server: meldinger } as ActionErrors }, { status: 400 })
+    }
+    return data({ errors: { _server: ['Det oppstod en feil ved lagring'] } as ActionErrors }, { status: 500 })
+  }
+}
+
+type LinjeStatus = 'original' | 'new' | 'modified' | 'deleted'
+
+type InntektLinjeState = InntektDTO & { _id: string; _status: LinjeStatus; _original: InntektDTO | null }
+type DagpengerLinjeState = DagpengerDTO & { _id: string; _status: LinjeStatus; _original: DagpengerDTO | null }
+type OmsorgLinjeState = OmsorgDTO & { _id: string; _status: LinjeStatus; _original: OmsorgDTO | null }
+type ForstegangstjenesteLinjeState = ForstegangstjenesteDTO & {
+  _id: string
+  _status: LinjeStatus
+  _original: ForstegangstjenesteDTO | null
+}
+
+export function tilLinjeState<T extends object>(dto: T): T & { _id: string; _status: LinjeStatus; _original: T } {
+  return { ...dto, _id: crypto.randomUUID(), _status: 'original' as LinjeStatus, _original: { ...dto } as T }
+}
+
+export function beregnStatus<T extends object>(
+  linje: T & { _status: LinjeStatus; _original: T | null },
+  felter: (keyof T)[],
+): LinjeStatus {
+  if (linje._status === 'new' || linje._status === 'deleted') return linje._status
+  if (!linje._original) return 'new'
+  const orig = linje._original
+  const endret = felter.some(k => (linje[k] ?? null) !== (orig[k] ?? null))
+  return endret ? 'modified' : 'original'
+}
+
+const INNTEKT_FELTER: (keyof InntektDTO)[] = ['inntektType', 'inntektAr', 'belop', 'kommune']
+const DAGPENGER_FELTER: (keyof DagpengerDTO)[] = [
+  'dagpengerType',
+  'ar',
+  'uavkortetDagpengegrunnlag',
+  'utbetalteDagpenger',
+  'ferietillegg',
+  'barnetillegg',
+]
+const FORSTEGANGSTJENESTE_FELTER: (keyof ForstegangstjenesteDTO)[] = [
+  'tjenesteType',
+  'periodeType',
+  'fomDato',
+  'tomDato',
+]
+
+export function nyInntektLinje(defaultType: string): InntektLinjeState {
+  return {
+    _id: crypto.randomUUID(),
+    _status: 'new',
+    _original: null,
+    inntektType: defaultType,
+    inntektAr: new Date().getFullYear(),
+    belop: null,
+    kommune: REQUIRED_KOMMUNE[defaultType] ?? null,
+  }
+}
+
+export function nyDagpengerLinje(): DagpengerLinjeState {
+  return {
+    _id: crypto.randomUUID(),
+    _status: 'new',
+    _original: null,
+    dagpengerType: 'DP',
+    ar: new Date().getFullYear(),
+    uavkortetDagpengegrunnlag: null,
+    utbetalteDagpenger: null,
+    ferietillegg: null,
+    barnetillegg: null,
+  }
+}
+
+export function nyForstegangstjenesteLinje(): ForstegangstjenesteLinjeState {
+  return {
+    _id: crypto.randomUUID(),
+    _status: 'new',
+    _original: null,
+    tjenesteType: 'MIL',
+    periodeType: null,
+    fomDato: '',
+    tomDato: '',
+  }
+}
+
+type EndringSummaryItem = {
+  id: string
+  kategori: string
+  label: string
+  endringer?: string[]
+}
+
+export function typeLabel(opptjeningstyper: OpptjeningstyperResponse, code: string): string {
+  const alle = [
+    ...opptjeningstyper.inntekt.typer,
+    ...opptjeningstyper.omsorg.typer,
+    ...opptjeningstyper.dagpenger.typer,
+    ...opptjeningstyper.forstegangstjeneste.typer,
+    ...opptjeningstyper.forstegangstjeneste.subTyper,
+  ]
+  return alle.find(t => t.code === code)?.description ?? code
+}
+
+export function oversettKoderIMelding(melding: string, opptjeningstyper: OpptjeningstyperResponse): string {
+  const alle = [
+    ...opptjeningstyper.inntekt.typer,
+    ...opptjeningstyper.omsorg.typer,
+    ...opptjeningstyper.dagpenger.typer,
+    ...opptjeningstyper.forstegangstjeneste.typer,
+    ...opptjeningstyper.forstegangstjeneste.subTyper,
+  ].sort((a, b) => b.code.length - a.code.length)
+
+  return alle.reduce((tekst, type) => {
+    const regex = new RegExp(`\\b${type.code}\\b`, 'g')
+    return tekst.replace(regex, `${type.description} (${type.code})`)
+  }, melding)
+}
+
+export function inntektEndringer(linje: InntektLinjeState, opptjeningstyper: OpptjeningstyperResponse): string[] {
+  if (!linje._original) return []
+  const orig = linje._original
+  const felter: string[] = []
+  if (linje.inntektType !== orig.inntektType) {
+    felter.push(
+      `Inntektstype: ${typeLabel(opptjeningstyper, orig.inntektType)} → ${typeLabel(opptjeningstyper, linje.inntektType)}`,
+    )
+  }
+  if (linje.inntektAr !== orig.inntektAr) {
+    felter.push(`År: ${orig.inntektAr} → ${linje.inntektAr}`)
+  }
+  if ((linje.belop ?? null) !== (orig.belop ?? null)) {
+    const fra = orig.belop != null ? formatCurrencyNok(orig.belop) : '–'
+    const til = linje.belop != null ? formatCurrencyNok(linje.belop) : '–'
+    felter.push(`Beløp: ${fra} → ${til}`)
+  }
+  if ((linje.kommune ?? null) !== (orig.kommune ?? null)) {
+    felter.push(`Skattekommune: ${orig.kommune ?? '–'} → ${linje.kommune ?? '–'}`)
+  }
+  return felter
+}
+
+export function dagpengerEndringer(linje: DagpengerLinjeState, opptjeningstyper: OpptjeningstyperResponse): string[] {
+  if (!linje._original) return []
+  const orig = linje._original
+  const felter: string[] = []
+  if (linje.dagpengerType !== orig.dagpengerType) {
+    felter.push(
+      `Type: ${typeLabel(opptjeningstyper, orig.dagpengerType)} → ${typeLabel(opptjeningstyper, linje.dagpengerType)}`,
+    )
+  }
+  if (linje.ar !== orig.ar) {
+    felter.push(`År: ${orig.ar} → ${linje.ar}`)
+  }
+  if (
+    (linje.uavkortetDagpengegrunnlag ?? null) !== (orig.uavkortetDagpengegrunnlag ?? null) &&
+    linje.dagpengerType !== 'DP_FF'
+  ) {
+    const fra = orig.uavkortetDagpengegrunnlag != null ? formatCurrencyNok(orig.uavkortetDagpengegrunnlag) : '–'
+    const til = linje.uavkortetDagpengegrunnlag != null ? formatCurrencyNok(linje.uavkortetDagpengegrunnlag) : '–'
+    felter.push(`Uavkortet grunnlag: ${fra} → ${til}`)
+  }
+  if ((linje.utbetalteDagpenger ?? null) !== (orig.utbetalteDagpenger ?? null)) {
+    const fra = orig.utbetalteDagpenger != null ? formatCurrencyNok(orig.utbetalteDagpenger) : '–'
+    const til = linje.utbetalteDagpenger != null ? formatCurrencyNok(linje.utbetalteDagpenger) : '–'
+    felter.push(`Utbetalte dagpenger: ${fra} → ${til}`)
+  }
+  if ((linje.ferietillegg ?? null) !== (orig.ferietillegg ?? null) && linje.dagpengerType !== 'DP_FF') {
+    const fra = orig.ferietillegg != null ? formatCurrencyNok(orig.ferietillegg) : '–'
+    const til = linje.ferietillegg != null ? formatCurrencyNok(linje.ferietillegg) : '–'
+    felter.push(`Ferietillegg: ${fra} → ${til}`)
+  }
+  if ((linje.barnetillegg ?? null) !== (orig.barnetillegg ?? null)) {
+    const fra = orig.barnetillegg != null ? formatCurrencyNok(orig.barnetillegg) : '–'
+    const til = linje.barnetillegg != null ? formatCurrencyNok(linje.barnetillegg) : '–'
+    felter.push(`Barnetillegg: ${fra} → ${til}`)
+  }
+  return felter
+}
+
+export function forstegangstjenesteEndringer(
+  linje: ForstegangstjenesteLinjeState,
+  opptjeningstyper: OpptjeningstyperResponse,
+): string[] {
+  if (!linje._original) return []
+  const orig = linje._original
+  const felter: string[] = []
+  if (linje.tjenesteType !== orig.tjenesteType) {
+    felter.push(
+      `Type: ${typeLabel(opptjeningstyper, orig.tjenesteType)} → ${typeLabel(opptjeningstyper, linje.tjenesteType)}`,
+    )
+  }
+  if ((linje.periodeType ?? null) !== (orig.periodeType ?? null)) {
+    const fra = orig.periodeType ? typeLabel(opptjeningstyper, orig.periodeType) : '–'
+    const til = linje.periodeType ? typeLabel(opptjeningstyper, linje.periodeType) : '–'
+    felter.push(`Periodetype: ${fra} → ${til}`)
+  }
+  if (linje.fomDato !== orig.fomDato) {
+    felter.push(`FOM: ${orig.fomDato || '–'} → ${linje.fomDato || '–'}`)
+  }
+  if (linje.tomDato !== orig.tomDato) {
+    felter.push(`TOM: ${orig.tomDato || '–'} → ${linje.tomDato || '–'}`)
+  }
+  return felter
+}
+
+export function toInntektBackend(l: InntektLinjeState, fnr: string): InntektBackendDTO {
+  return {
+    inntektId: l.inntektId ?? null,
+    fnr,
+    kilde: KILDE,
+    kommune: l.kommune ?? null,
+    piMerke: null,
+    inntektAr: Number(l.inntektAr),
+    belop: l.belop != null ? String(Number(l.belop)) : null,
+    inntektType: l.inntektType,
+  }
+}
+
+export function toDagpengerBackend(l: DagpengerLinjeState, fnr: string): DagpengerBackendDTO {
+  const isFF = l.dagpengerType === 'DP_FF'
+  return {
+    dagpengerId: l.dagpengerId ?? null,
+    fnr,
+    dagpengerType: l.dagpengerType,
+    kilde: KILDE,
+    ar: Number(l.ar),
+    utbetalteDagpenger: l.utbetalteDagpenger != null ? Number(l.utbetalteDagpenger) : null,
+    uavkortetDagpengegrunnlag: isFF
+      ? null
+      : l.uavkortetDagpengegrunnlag != null
+        ? Number(l.uavkortetDagpengegrunnlag)
+        : null,
+    ferietillegg: isFF ? null : l.ferietillegg != null ? Number(l.ferietillegg) : null,
+    barnetillegg: l.barnetillegg != null ? Number(l.barnetillegg) : null,
+  }
+}
+
+export function toOmsorgBackend(l: OmsorgLinjeState, fnr: string): OmsorgBackendDTO {
+  return {
+    omsorgId: l.omsorgId ?? null,
+    fnr,
+    fnrOmsorgFor: l.fnrOmsorgFor ?? null,
+    omsorgType: l.omsorgType,
+    kilde: KILDE,
+    ar: Number(l.ar),
+  }
+}
+
+export function toForstegangstjenesteBackend(
+  l: ForstegangstjenesteLinjeState,
+  fnr: string,
+): ForstegangstjenesteBackendDTO {
+  return {
+    forstegangstjenesteId: l.forstegangstjenesteId ?? null,
+    fnr,
+    kilde: KILDE,
+    tjenestestartDato: l.fomDato || null,
+    dimitteringDato: l.tomDato || null,
+    forstegangstjenestePeriodeListe: [
+      {
+        forstegangstjenestePeriodeId: null,
+        periodeType: l.periodeType ?? null,
+        tjenesteType: l.tjenesteType,
+        fomDato: l.fomDato || null,
+        tomDato: l.tomDato || null,
+      },
+    ],
+  }
+}
+
+export function inntektGrunnlagTilViewModel(dto: InntektBackendDTO): InntektDTO {
+  return {
+    inntektId: dto.inntektId ?? null,
+    kommune: dto.kommune ?? null,
+    inntektAr: dto.inntektAr ?? 0,
+    belop: dto.belop != null ? Number(dto.belop) : null,
+    inntektType: dto.inntektType ?? '',
+  }
+}
+
+export function dagpengerGrunnlagTilViewModel(dto: DagpengerBackendDTO): DagpengerDTO {
+  return {
+    dagpengerId: dto.dagpengerId ?? null,
+    ar: dto.ar ?? 0,
+    dagpengerType: dto.dagpengerType ?? '',
+    uavkortetDagpengegrunnlag: dto.uavkortetDagpengegrunnlag ?? null,
+    utbetalteDagpenger: dto.utbetalteDagpenger ?? null,
+    ferietillegg: dto.ferietillegg ?? null,
+    barnetillegg: dto.barnetillegg ?? null,
+  }
+}
+
+export function omsorgGrunnlagTilViewModel(dto: OmsorgBackendDTO): OmsorgDTO {
+  return {
+    omsorgId: dto.omsorgId ?? null,
+    ar: dto.ar ?? 0,
+    omsorgType: dto.omsorgType ?? '',
+    fnrOmsorgFor: dto.fnrOmsorgFor ?? null,
+  }
+}
+
+export function forstegangstjenesteGrunnlagTilViewModel(
+  dto: ForstegangstjenesteBackendDTO | null | undefined,
+): ForstegangstjenesteDTO[] {
+  if (!dto) return []
+  return (dto.forstegangstjenestePeriodeListe ?? []).map(periode => ({
+    forstegangstjenesteId: dto.forstegangstjenesteId ?? null,
+    tjenesteType: periode.tjenesteType ?? '',
+    periodeType: periode.periodeType ?? null,
+    fomDato: periode.fomDato ?? '',
+    tomDato: periode.tomDato ?? '',
+  }))
+}
+
+function StatusTag({ status }: { status: LinjeStatus }) {
+  if (status === 'new')
+    return (
+      <Tag variant="success" size="small">
+        Ny
+      </Tag>
+    )
+  if (status === 'modified')
+    return (
+      <Tag variant="warning" size="small">
+        Endret
+      </Tag>
+    )
+  if (status === 'deleted')
+    return (
+      <Tag variant="error" size="small">
+        Slettet
+      </Tag>
+    )
+  return null
+}
+
+function HandlingKnapper({
+  linje,
+  onSlett,
+  onGjenopprett,
+}: {
+  linje: { _id: string; _status: LinjeStatus }
+  onSlett: (id: string) => void
+  onGjenopprett: (id: string) => void
+}) {
+  if (linje._status === 'deleted') {
+    return (
+      <Button type="button" variant="tertiary" size="small" onClick={() => onGjenopprett(linje._id)}>
+        Gjenopprett
+      </Button>
+    )
+  }
+  return (
+    <Button
+      type="button"
+      variant="tertiary-neutral"
+      size="small"
+      icon={<TrashIcon aria-hidden />}
+      onClick={() => onSlett(linje._id)}
+    >
+      Slett
+    </Button>
+  )
+}
+
+function InntekterSeksjon({
+  linjer,
+  opptjeningstyper,
+  readOnly,
+  kommuneFeil,
+  onLeggTil,
+  onSlett,
+  onGjenopprett,
+  onOppdater,
+}: {
+  linjer: InntektLinjeState[]
+  opptjeningstyper: OpptjeningstyperResponse
+  readOnly: boolean
+  kommuneFeil: Record<string, string>
+  onLeggTil: () => void
+  onSlett: (id: string) => void
+  onGjenopprett: (id: string) => void
+  onOppdater: (id: string, felt: keyof InntektDTO, verdi: string) => void
+}) {
+  const sortert = useMemo(() => [...linjer].sort((a, b) => a.inntektAr - b.inntektAr), [linjer])
+
+  return (
+    <Box>
+      <Heading size="small" level="3" spacing>
+        Inntekter
+      </Heading>
+      {linjer.length === 0 ? (
+        <BodyShort>Ingen inntektslinjer registrert.</BodyShort>
+      ) : (
+        <Box style={{ overflowX: 'auto' }}>
+          <Table size="small">
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Inntektstype</Table.HeaderCell>
+                <Table.HeaderCell>År</Table.HeaderCell>
+                <Table.HeaderCell>Beløp</Table.HeaderCell>
+                <Table.HeaderCell>Skattekommune</Table.HeaderCell>
+                {!readOnly && <Table.HeaderCell>Status</Table.HeaderCell>}
+                {!readOnly && <Table.HeaderCell />}
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {sortert.map(linje => {
+                const erSlettet = linje._status === 'deleted'
+                const kommuneKravet = REQUIRED_KOMMUNE[linje.inntektType]
+                const kommuneDisabled = erSlettet || !!kommuneKravet
+                return (
+                  <Table.Row key={linje._id} style={erSlettet ? { opacity: 0.45 } : undefined}>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        (opptjeningstyper.inntekt.typer.find(t => t.code === linje.inntektType)?.description ??
+                        linje.inntektType)
+                      ) : (
+                        <Select
+                          label="Inntektstype"
+                          size="small"
+                          hideLabel
+                          value={linje.inntektType}
+                          onChange={e => onOppdater(linje._id, 'inntektType', e.target.value)}
+                          disabled={erSlettet}
+                          style={{ minWidth: '16rem' }}
+                        >
+                          {opptjeningstyper.inntekt.typer.map(t => (
+                            <option key={t.code} value={t.code}>
+                              {t.description}
+                            </option>
+                          ))}
+                        </Select>
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        linje.inntektAr
+                      ) : (
+                        <TextField
+                          label="År"
+                          hideLabel
+                          value={linje.inntektAr?.toString() ?? ''}
+                          onChange={e => onOppdater(linje._id, 'inntektAr', e.target.value)}
+                          inputMode="numeric"
+                          size="small"
+                          disabled={erSlettet}
+                          style={{ width: '5.5rem' }}
+                        />
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        linje.belop != null ? (
+                          formatCurrencyNok(linje.belop)
+                        ) : (
+                          '–'
+                        )
+                      ) : (
+                        <TextField
+                          label="Beløp"
+                          hideLabel
+                          value={linje.belop?.toString() ?? ''}
+                          onChange={e => onOppdater(linje._id, 'belop', e.target.value)}
+                          inputMode="decimal"
+                          size="small"
+                          disabled={erSlettet}
+                          style={{ width: '9rem' }}
+                        />
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        (linje.kommune ?? '–')
+                      ) : (
+                        <TextField
+                          label="Skattekommune"
+                          hideLabel
+                          value={linje.kommune ?? ''}
+                          onChange={e => onOppdater(linje._id, 'kommune', e.target.value)}
+                          size="small"
+                          disabled={kommuneDisabled}
+                          error={!kommuneDisabled ? kommuneFeil[linje._id] : undefined}
+                          style={{ width: '7rem' }}
+                        />
+                      )}
+                    </Table.DataCell>
+                    {!readOnly && (
+                      <Table.DataCell>
+                        <StatusTag status={linje._status} />
+                      </Table.DataCell>
+                    )}
+                    {!readOnly && (
+                      <Table.DataCell>
+                        <HandlingKnapper linje={linje} onSlett={onSlett} onGjenopprett={onGjenopprett} />
+                      </Table.DataCell>
+                    )}
+                  </Table.Row>
+                )
+              })}
+            </Table.Body>
+          </Table>
+        </Box>
+      )}
+      {!readOnly && (
+        <Box marginBlock="space-12 space-0">
+          <Button type="button" variant="secondary" size="small" icon={<PlusIcon aria-hidden />} onClick={onLeggTil}>
+            Legg til inntektslinje
+          </Button>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+function DagpengerSeksjon({
+  linjer,
+  opptjeningstyper,
+  readOnly,
+  onLeggTil,
+  onSlett,
+  onGjenopprett,
+  onOppdater,
+}: {
+  linjer: DagpengerLinjeState[]
+  opptjeningstyper: OpptjeningstyperResponse
+  readOnly: boolean
+  onLeggTil: () => void
+  onSlett: (id: string) => void
+  onGjenopprett: (id: string) => void
+  onOppdater: (id: string, felt: keyof DagpengerDTO, verdi: string) => void
+}) {
+  const sortert = useMemo(() => [...linjer].sort((a, b) => a.ar - b.ar), [linjer])
+  const erFF = (dagpengerType: string) => dagpengerType === 'DP_FF'
+
+  return (
+    <Box>
+      <Heading size="small" level="3" spacing>
+        Dagpenger
+      </Heading>
+      {linjer.length === 0 ? (
+        <BodyShort>Ingen dagpengelinjer registrert.</BodyShort>
+      ) : (
+        <Box style={{ overflowX: 'auto' }}>
+          <Table size="small">
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Type</Table.HeaderCell>
+                <Table.HeaderCell>År</Table.HeaderCell>
+                <Table.HeaderCell>Uavkortet grunnlag</Table.HeaderCell>
+                <Table.HeaderCell>Utbetalte dagpenger</Table.HeaderCell>
+                <Table.HeaderCell>Ferietillegg</Table.HeaderCell>
+                <Table.HeaderCell>Barnetillegg</Table.HeaderCell>
+                {!readOnly && <Table.HeaderCell>Status</Table.HeaderCell>}
+                {!readOnly && <Table.HeaderCell />}
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {sortert.map(linje => {
+                const erSlettet = linje._status === 'deleted'
+                const ff = erFF(linje.dagpengerType)
+                return (
+                  <Table.Row key={linje._id} style={erSlettet ? { opacity: 0.45 } : undefined}>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        (opptjeningstyper.dagpenger.typer.find(t => t.code === linje.dagpengerType)?.description ??
+                        linje.dagpengerType)
+                      ) : (
+                        <Select
+                          label="Type"
+                          size="small"
+                          hideLabel
+                          value={linje.dagpengerType}
+                          onChange={e => onOppdater(linje._id, 'dagpengerType', e.target.value)}
+                          disabled={erSlettet}
+                          style={{ minWidth: '14rem' }}
+                        >
+                          {opptjeningstyper.dagpenger.typer.map(t => (
+                            <option key={t.code} value={t.code}>
+                              {t.description}
+                            </option>
+                          ))}
+                        </Select>
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        linje.ar
+                      ) : (
+                        <TextField
+                          label="År"
+                          hideLabel
+                          value={linje.ar?.toString() ?? ''}
+                          onChange={e => onOppdater(linje._id, 'ar', e.target.value)}
+                          inputMode="numeric"
+                          size="small"
+                          disabled={erSlettet}
+                          style={{ width: '5.5rem' }}
+                        />
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        linje.uavkortetDagpengegrunnlag != null ? (
+                          formatCurrencyNok(linje.uavkortetDagpengegrunnlag)
+                        ) : (
+                          '–'
+                        )
+                      ) : (
+                        <TextField
+                          label="Uavkortet grunnlag"
+                          hideLabel
+                          value={linje.uavkortetDagpengegrunnlag?.toString() ?? ''}
+                          onChange={e => onOppdater(linje._id, 'uavkortetDagpengegrunnlag', e.target.value)}
+                          inputMode="decimal"
+                          size="small"
+                          disabled={erSlettet || ff}
+                          style={{ width: '9rem' }}
+                        />
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        linje.utbetalteDagpenger != null ? (
+                          formatCurrencyNok(linje.utbetalteDagpenger)
+                        ) : (
+                          '–'
+                        )
+                      ) : (
+                        <TextField
+                          label="Utbetalte dagpenger"
+                          hideLabel
+                          value={linje.utbetalteDagpenger?.toString() ?? ''}
+                          onChange={e => onOppdater(linje._id, 'utbetalteDagpenger', e.target.value)}
+                          inputMode="decimal"
+                          size="small"
+                          disabled={erSlettet}
+                          style={{ width: '9rem' }}
+                        />
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        linje.ferietillegg != null ? (
+                          formatCurrencyNok(linje.ferietillegg)
+                        ) : (
+                          '–'
+                        )
+                      ) : (
+                        <TextField
+                          label="Ferietillegg"
+                          hideLabel
+                          value={linje.ferietillegg?.toString() ?? ''}
+                          onChange={e => onOppdater(linje._id, 'ferietillegg', e.target.value)}
+                          inputMode="decimal"
+                          size="small"
+                          disabled={erSlettet || ff}
+                          style={{ width: '9rem' }}
+                        />
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        linje.barnetillegg != null ? (
+                          formatCurrencyNok(linje.barnetillegg)
+                        ) : (
+                          '–'
+                        )
+                      ) : (
+                        <TextField
+                          label="Barnetillegg"
+                          hideLabel
+                          value={linje.barnetillegg?.toString() ?? ''}
+                          onChange={e => onOppdater(linje._id, 'barnetillegg', e.target.value)}
+                          inputMode="decimal"
+                          size="small"
+                          disabled={erSlettet}
+                          style={{ width: '9rem' }}
+                        />
+                      )}
+                    </Table.DataCell>
+                    {!readOnly && (
+                      <Table.DataCell>
+                        <StatusTag status={linje._status} />
+                      </Table.DataCell>
+                    )}
+                    {!readOnly && (
+                      <Table.DataCell>
+                        <HandlingKnapper linje={linje} onSlett={onSlett} onGjenopprett={onGjenopprett} />
+                      </Table.DataCell>
+                    )}
+                  </Table.Row>
+                )
+              })}
+            </Table.Body>
+          </Table>
+        </Box>
+      )}
+      {!readOnly && (
+        <Box marginBlock="space-12 space-0">
+          <Button type="button" variant="secondary" size="small" icon={<PlusIcon aria-hidden />} onClick={onLeggTil}>
+            Legg til dagpengelinje
+          </Button>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+function OmsorgSeksjon({
+  linjer,
+  opptjeningstyper,
+  readOnly,
+  onSlett,
+  onGjenopprett,
+}: {
+  linjer: OmsorgLinjeState[]
+  opptjeningstyper: OpptjeningstyperResponse
+  readOnly: boolean
+  onSlett: (id: string) => void
+  onGjenopprett: (id: string) => void
+}) {
+  const sortert = useMemo(() => [...linjer].sort((a, b) => a.ar - b.ar), [linjer])
+
+  if (linjer.length === 0) return null
+
+  return (
+    <Box>
+      <Heading size="small" level="3" spacing>
+        Omsorg
+      </Heading>
+      <Box style={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Type</Table.HeaderCell>
+              <Table.HeaderCell>År</Table.HeaderCell>
+              <Table.HeaderCell>Omsorg for (fnr)</Table.HeaderCell>
+              {!readOnly && <Table.HeaderCell>Status</Table.HeaderCell>}
+              {!readOnly && <Table.HeaderCell />}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {sortert.map(linje => {
+              const erSlettet = linje._status === 'deleted'
+              return (
+                <Table.Row key={linje._id} style={erSlettet ? { opacity: 0.45 } : undefined}>
+                  <Table.DataCell>
+                    {opptjeningstyper.omsorg.typer.find(t => t.code === linje.omsorgType)?.description ??
+                      linje.omsorgType}
+                  </Table.DataCell>
+                  <Table.DataCell>{linje.ar}</Table.DataCell>
+                  <Table.DataCell>{linje.fnrOmsorgFor ? <Fnr value={linje.fnrOmsorgFor} /> : '–'}</Table.DataCell>
+                  {!readOnly && (
+                    <Table.DataCell>
+                      <StatusTag status={linje._status} />
+                    </Table.DataCell>
+                  )}
+                  {!readOnly && (
+                    <Table.DataCell>
+                      <HandlingKnapper linje={linje} onSlett={onSlett} onGjenopprett={onGjenopprett} />
+                    </Table.DataCell>
+                  )}
+                </Table.Row>
+              )
+            })}
+          </Table.Body>
+        </Table>
+      </Box>
+    </Box>
+  )
+}
+
+export function parseIsoDate(iso: string): Date | undefined {
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return undefined
+  return new Date(y, m - 1, d)
+}
+
+export function toIsoDate(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+function DatoVelgerCell({
+  value,
+  label,
+  disabled,
+  error,
+  fromDate,
+  onChange,
+}: {
+  value: string
+  label: string
+  disabled?: boolean
+  error?: string
+  fromDate?: Date
+  onChange: (val: string) => void
+}) {
+  const { inputProps, datepickerProps } = useDatepicker({
+    defaultSelected: value ? parseIsoDate(value) : undefined,
+    fromDate,
+    onDateChange: date => onChange(date ? toIsoDate(date) : ''),
+  })
+  return (
+    <DatePicker dropdownCaption {...datepickerProps}>
+      <DatePicker.Input {...inputProps} label={label} hideLabel size="small" disabled={disabled} error={error} />
+    </DatePicker>
+  )
+}
+
+function ForstegangstjenesteSeksjon({
+  linjer,
+  opptjeningstyper,
+  readOnly,
+  fomFeil,
+  onLeggTil,
+  onSlett,
+  onGjenopprett,
+  onOppdater,
+}: {
+  linjer: ForstegangstjenesteLinjeState[]
+  opptjeningstyper: OpptjeningstyperResponse
+  readOnly: boolean
+  fomFeil: Record<string, string>
+  onLeggTil: () => void
+  onSlett: (id: string) => void
+  onGjenopprett: (id: string) => void
+  onOppdater: (id: string, felt: keyof ForstegangstjenesteDTO, verdi: string) => void
+}) {
+  return (
+    <Box>
+      <Heading size="small" level="3" spacing>
+        Førstegangstjeneste
+      </Heading>
+      {linjer.length === 0 ? (
+        <BodyShort>Ingen førstegangstjenestelinjer registrert.</BodyShort>
+      ) : (
+        <Box style={{ overflowX: 'auto' }}>
+          <Table size="small">
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Type</Table.HeaderCell>
+                <Table.HeaderCell>Periodetype</Table.HeaderCell>
+                <Table.HeaderCell>FOM</Table.HeaderCell>
+                <Table.HeaderCell>TOM</Table.HeaderCell>
+                {!readOnly && <Table.HeaderCell>Status</Table.HeaderCell>}
+                {!readOnly && <Table.HeaderCell />}
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {linjer.map(linje => {
+                const erSlettet = linje._status === 'deleted'
+                return (
+                  <Table.Row key={linje._id} style={erSlettet ? { opacity: 0.45 } : undefined}>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        (opptjeningstyper.forstegangstjeneste.typer.find(t => t.code === linje.tjenesteType)
+                          ?.description ?? linje.tjenesteType)
+                      ) : (
+                        <Select
+                          label="Type"
+                          size="small"
+                          hideLabel
+                          value={linje.tjenesteType}
+                          onChange={e => onOppdater(linje._id, 'tjenesteType', e.target.value)}
+                          disabled={erSlettet}
+                          style={{ minWidth: '12rem' }}
+                        >
+                          {opptjeningstyper.forstegangstjeneste.typer.map(t => (
+                            <option key={t.code} value={t.code}>
+                              {t.description}
+                            </option>
+                          ))}
+                        </Select>
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        (opptjeningstyper.forstegangstjeneste.subTyper.find(t => t.code === linje.periodeType)
+                          ?.description ??
+                        linje.periodeType ??
+                        '–')
+                      ) : (
+                        <Select
+                          label="Periodetype"
+                          size="small"
+                          hideLabel
+                          value={linje.periodeType ?? ''}
+                          onChange={e => onOppdater(linje._id, 'periodeType', e.target.value)}
+                          disabled={erSlettet}
+                          style={{ minWidth: '10rem' }}
+                        >
+                          <option value="">–</option>
+                          {opptjeningstyper.forstegangstjeneste.subTyper.map(t => (
+                            <option key={t.code} value={t.code}>
+                              {t.description}
+                            </option>
+                          ))}
+                        </Select>
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        linje.fomDato || '–'
+                      ) : (
+                        <DatoVelgerCell
+                          value={linje.fomDato}
+                          label="FOM"
+                          disabled={erSlettet}
+                          error={!erSlettet ? fomFeil[linje._id] : undefined}
+                          fromDate={new Date(2010, 0, 1)}
+                          onChange={val => onOppdater(linje._id, 'fomDato', val)}
+                        />
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {readOnly ? (
+                        linje.tomDato || '–'
+                      ) : (
+                        <DatoVelgerCell
+                          value={linje.tomDato}
+                          label="TOM"
+                          disabled={erSlettet}
+                          fromDate={new Date(2010, 0, 1)}
+                          onChange={val => onOppdater(linje._id, 'tomDato', val)}
+                        />
+                      )}
+                    </Table.DataCell>
+                    {!readOnly && (
+                      <Table.DataCell>
+                        <StatusTag status={linje._status} />
+                      </Table.DataCell>
+                    )}
+                    {!readOnly && (
+                      <Table.DataCell>
+                        <HandlingKnapper linje={linje} onSlett={onSlett} onGjenopprett={onGjenopprett} />
+                      </Table.DataCell>
+                    )}
+                  </Table.Row>
+                )
+              })}
+            </Table.Body>
+          </Table>
+        </Box>
+      )}
+      {!readOnly && (
+        <Box marginBlock="space-12 space-0">
+          <Button type="button" variant="secondary" size="small" icon={<PlusIcon aria-hidden />} onClick={onLeggTil}>
+            Legg til førstegangstjeneste
+          </Button>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default function OppdaterGrunnlagRoute({ loaderData, actionData }: Route.ComponentProps) {
+  const { grunnlag, opptjeningstyper, readOnly } = loaderData
+  const { errors } = actionData || {}
+  const { avbrytAktivitet } = useOutletContext<AktivitetOutletContext>()
+  const isSubmitting = useIsSubmitting()
+
+  const saker = grunnlag.saker ?? []
+  const [selectedSakId, setSelectedSakId] = useState('')
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
+  const sakIdFeil = saker.length > 0 && !selectedSakId ? 'Du må velge en sak før du kan lagre' : undefined
+
+  const defaultInntektType = opptjeningstyper.inntekt.typer[0]?.code ?? ''
+
+  const grunnlagDto = grunnlag.opptjeningsGrunnlagDto
+
+  const [inntektLinjer, setInntektLinjer] = useState<InntektLinjeState[]>(() => {
+    const fraGrunnlag = (grunnlagDto?.inntektListe ?? []).map(inntektGrunnlagTilViewModel)
+    if (fraGrunnlag.length > 0) return fraGrunnlag.map(tilLinjeState)
+    return [nyInntektLinje(defaultInntektType)]
+  })
+
+  const [dagpengerLinjer, setDagpengerLinjer] = useState<DagpengerLinjeState[]>(() =>
+    (grunnlagDto?.dagpengerListe ?? []).map(dagpengerGrunnlagTilViewModel).map(tilLinjeState),
+  )
+
+  const [omsorgLinjer, setOmsorgLinjer] = useState<OmsorgLinjeState[]>(() =>
+    (grunnlagDto?.omsorgListe ?? []).map(omsorgGrunnlagTilViewModel).map(tilLinjeState),
+  )
+
+  const [forstegangstjenesteLinjer, setForstegangstjenesteLinjer] = useState<ForstegangstjenesteLinjeState[]>(() =>
+    forstegangstjenesteGrunnlagTilViewModel(grunnlagDto?.forstegangstjeneste).map(tilLinjeState),
+  )
+
+  const slettInntektLinje = (id: string) =>
+    setInntektLinjer(prev => {
+      const linje = prev.find(l => l._id === id)
+      if (!linje) return prev
+      if (linje._status === 'new') return prev.filter(l => l._id !== id)
+      return prev.map(l => (l._id === id ? { ...l, _status: 'deleted' as const } : l))
+    })
+
+  const gjenopprettInntektLinje = (id: string) =>
+    setInntektLinjer(prev =>
+      prev.map(l => {
+        if (l._id !== id) return l
+        const restored = { ...l, _status: 'original' as const }
+        return { ...restored, _status: beregnStatus(restored, INNTEKT_FELTER) }
+      }),
+    )
+
+  const slettDagpengerLinje = (id: string) =>
+    setDagpengerLinjer(prev => {
+      const linje = prev.find(l => l._id === id)
+      if (!linje) return prev
+      if (linje._status === 'new') return prev.filter(l => l._id !== id)
+      return prev.map(l => (l._id === id ? { ...l, _status: 'deleted' as const } : l))
+    })
+
+  const gjenopprettDagpengerLinje = (id: string) =>
+    setDagpengerLinjer(prev =>
+      prev.map(l => {
+        if (l._id !== id) return l
+        const restored = { ...l, _status: 'original' as const }
+        return { ...restored, _status: beregnStatus(restored, DAGPENGER_FELTER) }
+      }),
+    )
+
+  const slettOmsorgLinje = (id: string) =>
+    setOmsorgLinjer(prev => {
+      const linje = prev.find(l => l._id === id)
+      if (!linje) return prev
+      if (linje._status === 'new') return prev.filter(l => l._id !== id)
+      return prev.map(l => (l._id === id ? { ...l, _status: 'deleted' as const } : l))
+    })
+
+  const gjenopprettOmsorgLinje = (id: string) =>
+    setOmsorgLinjer(prev =>
+      prev.map(l => {
+        if (l._id !== id) return l
+        const restored = { ...l, _status: 'original' as const }
+        return { ...restored, _status: beregnStatus(restored, ['omsorgType', 'ar', 'fnrOmsorgFor']) }
+      }),
+    )
+
+  const slettForstegangstjenesteLinje = (id: string) =>
+    setForstegangstjenesteLinjer(prev => {
+      const linje = prev.find(l => l._id === id)
+      if (!linje) return prev
+      if (linje._status === 'new') return prev.filter(l => l._id !== id)
+      return prev.map(l => (l._id === id ? { ...l, _status: 'deleted' as const } : l))
+    })
+
+  const gjenopprettForstegangstjenesteLinje = (id: string) =>
+    setForstegangstjenesteLinjer(prev =>
+      prev.map(l => {
+        if (l._id !== id) return l
+        const restored = { ...l, _status: 'original' as const }
+        return { ...restored, _status: beregnStatus(restored, FORSTEGANGSTJENESTE_FELTER) }
+      }),
+    )
+
+  const oppdaterInntektLinje = (id: string, felt: keyof InntektDTO, verdi: string) => {
+    setInntektLinjer(prev =>
+      prev.map(l => {
+        if (l._id !== id) return l
+        let updated: InntektLinjeState
+        if (felt === 'inntektAr') {
+          const n = Number(verdi.replace(/\D/g, ''))
+          updated = { ...l, inntektAr: n || l.inntektAr }
+        } else if (felt === 'belop') {
+          const clean = verdi.replace(/\D/g, '')
+          updated = { ...l, belop: clean ? Number(clean) : null }
+        } else if (felt === 'inntektType') {
+          const requiredKommune = REQUIRED_KOMMUNE[verdi]
+          updated = { ...l, inntektType: verdi, ...(requiredKommune !== undefined ? { kommune: requiredKommune } : {}) }
+        } else {
+          updated = { ...l, [felt]: verdi || null }
+        }
+        const status = beregnStatus(updated, INNTEKT_FELTER)
+        return { ...updated, _status: status }
+      }),
+    )
+  }
+
+  const oppdaterDagpengerLinje = (id: string, felt: keyof DagpengerDTO, verdi: string) => {
+    setDagpengerLinjer(prev =>
+      prev.map(l => {
+        if (l._id !== id) return l
+        const NUMERIC: (keyof DagpengerDTO)[] = [
+          'uavkortetDagpengegrunnlag',
+          'utbetalteDagpenger',
+          'ferietillegg',
+          'barnetillegg',
+        ]
+        let updated: DagpengerLinjeState
+        if (felt === 'dagpengerType') {
+          if (l._original && verdi === l._original.dagpengerType) {
+            updated = { ...l, ...l._original, _id: l._id, _status: l._status, _original: l._original }
+          } else {
+            updated = { ...l, dagpengerType: verdi }
+          }
+        } else if (felt === 'ar') {
+          const n = Number(verdi.replace(/\D/g, ''))
+          updated = { ...l, ar: n || l.ar }
+        } else if (NUMERIC.includes(felt)) {
+          const clean = verdi.replace(/\D/g, '')
+          updated = { ...l, [felt]: clean ? Number(clean) : null }
+        } else {
+          updated = { ...l, [felt]: verdi || null }
+        }
+        const status = beregnStatus(updated, DAGPENGER_FELTER)
+        return { ...updated, _status: status }
+      }),
+    )
+  }
+
+  const oppdaterForstegangstjenesteLinje = (id: string, felt: keyof ForstegangstjenesteDTO, verdi: string) => {
+    setForstegangstjenesteLinjer(prev =>
+      prev.map(l => {
+        if (l._id !== id) return l
+        const updated: ForstegangstjenesteLinjeState = { ...l, [felt]: verdi || null }
+        const status = beregnStatus(updated, FORSTEGANGSTJENESTE_FELTER)
+        return { ...updated, _status: status }
+      }),
+    )
+  }
+
+  const inntektKommuneFeil = useMemo(() => {
+    const feil: Record<string, string> = {}
+    for (const linje of inntektLinjer) {
+      if (linje._status === 'deleted') continue
+      const required = REQUIRED_KOMMUNE[linje.inntektType]
+      if (required && linje.kommune?.trim() !== required) {
+        feil[linje._id] = `Skattekommune for denne inntektstypen må være ${required}`
+      }
+    }
+    return feil
+  }, [inntektLinjer])
+
+  const forstegangstjenesteFomFeil = useMemo(() => {
+    const feil: Record<string, string> = {}
+    for (const linje of forstegangstjenesteLinjer) {
+      if (linje._status === 'deleted') continue
+      if (linje.fomDato && linje.fomDato < '2010-01-01') {
+        feil[linje._id] = 'Tjenestestartdato kan ikke være før 01.01.2010'
+      }
+    }
+    return feil
+  }, [forstegangstjenesteLinjer])
+
+  const harKlientFeil = Object.keys(inntektKommuneFeil).length > 0 || Object.keys(forstegangstjenesteFomFeil).length > 0
+
+  const endringSummary = useMemo<{
+    nye: EndringSummaryItem[]
+    endrede: EndringSummaryItem[]
+    slettede: EndringSummaryItem[]
+  }>(
+    () => ({
+      nye: [
+        ...inntektLinjer
+          .filter(l => l._status === 'new')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Inntekt',
+            label: `${typeLabel(opptjeningstyper, l.inntektType)} (${l.inntektAr})${l.belop != null ? ` – ${formatCurrencyNok(l.belop)}` : ''}`,
+          })),
+        ...dagpengerLinjer
+          .filter(l => l._status === 'new')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Dagpenger',
+            label: [
+              `${typeLabel(opptjeningstyper, l.dagpengerType)} (${l.ar})`,
+              l.dagpengerType !== 'DP_FF' &&
+                l.uavkortetDagpengegrunnlag != null &&
+                `grunnlag: ${formatCurrencyNok(l.uavkortetDagpengegrunnlag)}`,
+              l.utbetalteDagpenger != null && `utbetalt: ${formatCurrencyNok(l.utbetalteDagpenger)}`,
+              l.dagpengerType !== 'DP_FF' && l.ferietillegg != null && `ferie: ${formatCurrencyNok(l.ferietillegg)}`,
+              l.barnetillegg != null && `barn: ${formatCurrencyNok(l.barnetillegg)}`,
+            ]
+              .filter(Boolean)
+              .join(' – '),
+          })),
+        ...forstegangstjenesteLinjer
+          .filter(l => l._status === 'new')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Førstegangstjeneste',
+            label: `${typeLabel(opptjeningstyper, l.tjenesteType)}${l.periodeType ? ` / ${typeLabel(opptjeningstyper, l.periodeType)}` : ''} – ${l.fomDato || '?'} til ${l.tomDato || '?'}`,
+          })),
+      ],
+      endrede: [
+        ...inntektLinjer
+          .filter(l => l._status === 'modified')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Inntekt',
+            label: `${typeLabel(opptjeningstyper, l.inntektType)} (${l.inntektAr})`,
+            endringer: inntektEndringer(l, opptjeningstyper),
+          })),
+        ...dagpengerLinjer
+          .filter(l => l._status === 'modified')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Dagpenger',
+            label: `${typeLabel(opptjeningstyper, l.dagpengerType)} (${l.ar})`,
+            endringer: dagpengerEndringer(l, opptjeningstyper),
+          })),
+        ...forstegangstjenesteLinjer
+          .filter(l => l._status === 'modified')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Førstegangstjeneste',
+            label: `${typeLabel(opptjeningstyper, l.tjenesteType)} (${l.fomDato?.slice(0, 4) ?? '?'})`,
+            endringer: forstegangstjenesteEndringer(l, opptjeningstyper),
+          })),
+      ],
+      slettede: [
+        ...inntektLinjer
+          .filter(l => l._status === 'deleted')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Inntekt',
+            label: `${typeLabel(opptjeningstyper, l.inntektType)} (${l.inntektAr})${l.belop != null ? ` – ${formatCurrencyNok(l.belop)}` : ''}`,
+          })),
+        ...dagpengerLinjer
+          .filter(l => l._status === 'deleted')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Dagpenger',
+            label: [
+              `${typeLabel(opptjeningstyper, l.dagpengerType)} (${l.ar})`,
+              l.dagpengerType !== 'DP_FF' &&
+                l.uavkortetDagpengegrunnlag != null &&
+                `grunnlag: ${formatCurrencyNok(l.uavkortetDagpengegrunnlag)}`,
+              l.utbetalteDagpenger != null && `utbetalt: ${formatCurrencyNok(l.utbetalteDagpenger)}`,
+              l.dagpengerType !== 'DP_FF' && l.ferietillegg != null && `ferie: ${formatCurrencyNok(l.ferietillegg)}`,
+              l.barnetillegg != null && `barn: ${formatCurrencyNok(l.barnetillegg)}`,
+            ]
+              .filter(Boolean)
+              .join(' – '),
+          })),
+        ...omsorgLinjer
+          .filter(l => l._status === 'deleted')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Omsorg',
+            label: `${typeLabel(opptjeningstyper, l.omsorgType)} (${l.ar})${l.fnrOmsorgFor ? ` – omsorg for ${l.fnrOmsorgFor}` : ''}`,
+          })),
+        ...forstegangstjenesteLinjer
+          .filter(l => l._status === 'deleted')
+          .map(l => ({
+            id: l._id,
+            kategori: 'Førstegangstjeneste',
+            label: `${typeLabel(opptjeningstyper, l.tjenesteType)}${l.periodeType ? ` / ${typeLabel(opptjeningstyper, l.periodeType)}` : ''} – ${l.fomDato || '?'} til ${l.tomDato || '?'}`,
+          })),
+      ],
+    }),
+    [inntektLinjer, dagpengerLinjer, omsorgLinjer, forstegangstjenesteLinjer, opptjeningstyper],
+  )
+
+  const harEndringer = endringSummary.nye.length + endringSummary.endrede.length + endringSummary.slettede.length > 0
+
+  const payload = useMemo(() => {
+    const fnr = grunnlag.opptjeningsGrunnlagDto?.fnr ?? ''
+
+    const byStatus = <T extends { _status: LinjeStatus }>(linjer: T[]) => ({
+      nye: linjer.filter(l => l._status === 'new'),
+      endrede: linjer.filter(l => l._status === 'modified'),
+      slettede: linjer.filter(l => l._status === 'deleted'),
+    })
+
+    const inntekt = byStatus(inntektLinjer)
+    const dagpenger = byStatus(dagpengerLinjer)
+    const omsorg = byStatus(omsorgLinjer)
+    const ft = byStatus(forstegangstjenesteLinjer)
+
+    return JSON.stringify({
+      fnr,
+      inntektEndringer: [
+        ...(inntekt.nye.length > 0
+          ? [{ endringstype: 'OPPRETT', inntektListe: inntekt.nye.map(l => toInntektBackend(l, fnr)) }]
+          : []),
+        ...(inntekt.endrede.length > 0
+          ? [{ endringstype: 'OPPDATER', inntektListe: inntekt.endrede.map(l => toInntektBackend(l, fnr)) }]
+          : []),
+        ...(inntekt.slettede.length > 0
+          ? [{ endringstype: 'SLETT', inntektListe: inntekt.slettede.map(l => toInntektBackend(l, fnr)) }]
+          : []),
+      ],
+      dagpengerEndringer: [
+        ...(dagpenger.nye.length > 0
+          ? [{ endringstype: 'OPPRETT', dagpengerListe: dagpenger.nye.map(l => toDagpengerBackend(l, fnr)) }]
+          : []),
+        ...(dagpenger.endrede.length > 0
+          ? [{ endringstype: 'OPPDATER', dagpengerListe: dagpenger.endrede.map(l => toDagpengerBackend(l, fnr)) }]
+          : []),
+        ...(dagpenger.slettede.length > 0
+          ? [{ endringstype: 'SLETT', dagpengerListe: dagpenger.slettede.map(l => toDagpengerBackend(l, fnr)) }]
+          : []),
+      ],
+      omsorgEndringer: [
+        ...(omsorg.slettede.length > 0
+          ? [{ endringstype: 'SLETT', omsorgListe: omsorg.slettede.map(l => toOmsorgBackend(l, fnr)) }]
+          : []),
+      ],
+      forstegangstjenesteEndringer: [
+        ...ft.nye.map(l => ({ endringstype: 'OPPRETT', forstegangstjeneste: toForstegangstjenesteBackend(l, fnr) })),
+        ...ft.endrede.map(l => ({
+          endringstype: 'OPPDATER',
+          forstegangstjeneste: toForstegangstjenesteBackend(l, fnr),
+        })),
+        ...ft.slettede.map(l => ({ endringstype: 'SLETT', forstegangstjeneste: toForstegangstjenesteBackend(l, fnr) })),
+      ],
+    })
+  }, [grunnlag, inntektLinjer, dagpengerLinjer, omsorgLinjer, forstegangstjenesteLinjer])
+
+  const seksjoner = (
+    <VStack gap="space-24">
+      <InntekterSeksjon
+        linjer={inntektLinjer}
+        opptjeningstyper={opptjeningstyper}
+        readOnly={readOnly}
+        kommuneFeil={inntektKommuneFeil}
+        onLeggTil={() => setInntektLinjer(prev => [...prev, nyInntektLinje(defaultInntektType)])}
+        onSlett={slettInntektLinje}
+        onGjenopprett={gjenopprettInntektLinje}
+        onOppdater={oppdaterInntektLinje}
+      />
+      <DagpengerSeksjon
+        linjer={dagpengerLinjer}
+        opptjeningstyper={opptjeningstyper}
+        readOnly={readOnly}
+        onLeggTil={() => setDagpengerLinjer(prev => [...prev, nyDagpengerLinje()])}
+        onSlett={slettDagpengerLinje}
+        onGjenopprett={gjenopprettDagpengerLinje}
+        onOppdater={oppdaterDagpengerLinje}
+      />
+      <OmsorgSeksjon
+        linjer={omsorgLinjer}
+        opptjeningstyper={opptjeningstyper}
+        readOnly={readOnly}
+        onSlett={slettOmsorgLinje}
+        onGjenopprett={gjenopprettOmsorgLinje}
+      />
+      <ForstegangstjenesteSeksjon
+        linjer={forstegangstjenesteLinjer}
+        opptjeningstyper={opptjeningstyper}
+        readOnly={readOnly}
+        fomFeil={forstegangstjenesteFomFeil}
+        onLeggTil={() => setForstegangstjenesteLinjer(prev => [...prev, nyForstegangstjenesteLinje()])}
+        onSlett={slettForstegangstjenesteLinje}
+        onGjenopprett={gjenopprettForstegangstjenesteLinje}
+        onOppdater={oppdaterForstegangstjenesteLinje}
+      />
+    </VStack>
+  )
+
+  return (
+    <Page.Block gutters className={styles.page}>
+      <VStack gap="space-32">
+        <Heading size="medium" level="2">
+          Oppdater opptjeningsgrunnlag
+        </Heading>
+
+        {readOnly && (
+          <LocalAlert status="warning">
+            <LocalAlert.Header>
+              <LocalAlert.Title>Mangler rolle tilgang</LocalAlert.Title>
+            </LocalAlert.Header>
+            <LocalAlert.Content>
+              Kun saksbehandlere med tilleggsrolle «Spesial PGI» kan gjøre endringer i Opptjeningsregisteret.
+            </LocalAlert.Content>
+          </LocalAlert>
+        )}
+
+        {errors?._form && (
+          <LocalAlert status="error">
+            <LocalAlert.Header>
+              <LocalAlert.Title>Feilmelding</LocalAlert.Title>
+            </LocalAlert.Header>
+            <LocalAlert.Content>{errors._form}</LocalAlert.Content>
+          </LocalAlert>
+        )}
+
+        {readOnly ? (
+          seksjoner
+        ) : (
+          <Form
+            method="post"
+            onSubmit={e => {
+              setHasAttemptedSubmit(true)
+              if (!harEndringer) e.preventDefault()
+            }}
+          >
+            <VStack gap="space-24">
+              {saker.length > 0 && (
+                <Box>
+                  <Heading size="small" level="3" spacing>
+                    Velg sak
+                  </Heading>
+                  <Select
+                    label="Sak"
+                    name="sakId"
+                    size="small"
+                    value={selectedSakId}
+                    onChange={e => setSelectedSakId(e.target.value)}
+                  >
+                    <option value="">Velg sak</option>
+                    {saker.map(sak => (
+                      <option key={sak.sakId} value={sak.sakId}>
+                        {sak.sakId}
+                        {sak.sakType ? ` – ${sak.sakType}` : ''}
+                        {sak.sakStatus ? ` (${sak.sakStatus})` : ''}
+                      </option>
+                    ))}
+                  </Select>
+                </Box>
+              )}
+
+              {seksjoner}
+
+              {harEndringer && (
+                <InfoCard data-color="info">
+                  <InfoCard.Header icon={<InformationSquareIcon aria-hidden />}>
+                    <InfoCard.Title>Endringer som vil bli lagret</InfoCard.Title>
+                  </InfoCard.Header>
+                  <InfoCard.Content>
+                    <VStack gap="space-12">
+                      {endringSummary.nye.length > 0 && (
+                        <div>
+                          <strong>Nye linjer ({endringSummary.nye.length})</strong>
+                          <ul>
+                            {endringSummary.nye.map(item => (
+                              <li key={item.id}>
+                                {item.kategori}: {item.label}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                      {endringSummary.endrede.length > 0 && (
+                        <div>
+                          <strong>Endrede linjer ({endringSummary.endrede.length})</strong>
+                          <ul>
+                            {endringSummary.endrede.map(item => (
+                              <li key={item.id}>
+                                {item.kategori}: {item.label}
+                                {item.endringer && item.endringer.length > 0 && (
+                                  <ul>
+                                    {item.endringer.map(e => (
+                                      <li key={e}>{e}</li>
+                                    ))}
+                                  </ul>
+                                )}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                      {endringSummary.slettede.length > 0 && (
+                        <div>
+                          <strong>Slettede linjer ({endringSummary.slettede.length})</strong>
+                          <ul>
+                            {endringSummary.slettede.map(item => (
+                              <li key={item.id}>
+                                {item.kategori}: {item.label}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </VStack>
+                  </InfoCard.Content>
+                </InfoCard>
+              )}
+
+              <input type="hidden" name="payload" value={payload} />
+
+              {sakIdFeil && <InlineMessage status="error">{sakIdFeil}</InlineMessage>}
+
+              {hasAttemptedSubmit && !harEndringer && (
+                <InlineMessage status="error">
+                  Ingen endringer er registrert. Gjør minst én endring før du lagrer.
+                </InlineMessage>
+              )}
+
+              {errors?._server && errors._server.length > 0 && (
+                <LocalAlert status="error">
+                  <LocalAlert.Header>
+                    <LocalAlert.Title>Vennligst sjekk følgende feil</LocalAlert.Title>
+                  </LocalAlert.Header>
+                  <LocalAlert.Content>
+                    <VStack gap="space-4">
+                      <ul>
+                        {Array.from(new Set(errors._server)).map(melding => (
+                          <li key={melding}>{oversettKoderIMelding(melding, opptjeningstyper)}</li>
+                        ))}
+                      </ul>
+                    </VStack>
+                  </LocalAlert.Content>
+                </LocalAlert>
+              )}
+
+              <HStack gap="space-8">
+                <Button
+                  type="submit"
+                  variant="primary"
+                  size="small"
+                  loading={isSubmitting}
+                  disabled={harKlientFeil || !!sakIdFeil}
+                >
+                  Lagre og gå videre
+                </Button>
+                <Button type="button" variant="tertiary" size="small" onClick={avbrytAktivitet} disabled={isSubmitting}>
+                  Avbryt behandling
+                </Button>
+                {/* DEBUG */}
+                <Button
+                  type="button"
+                  variant="tertiary-neutral"
+                  size="small"
+                  onClick={() => console.log('[DEBUG payload]', JSON.parse(payload))}
+                >
+                  Log payload
+                </Button>
+              </HStack>
+            </VStack>
+          </Form>
+        )}
+      </VStack>
+    </Page.Block>
+  )
+}

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
@@ -144,7 +144,7 @@ export async function action({ params, request }: Route.ActionArgs) {
   }))
 
   const sakId = sakIdRaw ? Number(sakIdRaw) : undefined
-  if (sakIdRaw && (isNaN(sakId as number) || !Number.isInteger(sakId))) {
+  if (sakIdRaw && (Number.isNaN(sakId as number) || !Number.isInteger(sakId))) {
     return data({ errors: { _form: 'Ugyldig sakId' } as ActionErrors }, { status: 400 })
   }
 
@@ -1279,7 +1279,7 @@ export default function OppdaterGrunnlagRoute({ loaderData, actionData }: Route.
     setForstegangstjenesteLinjer(prev =>
       prev.map(l => {
         if (l._id !== id) return l
-        const feltVerdi = felt === 'periodeType' ? (verdi || null) : verdi
+        const feltVerdi = felt === 'periodeType' ? verdi || null : verdi
         const updated: ForstegangstjenesteLinjeState = { ...l, [felt]: feltVerdi }
         const status = beregnStatus(updated, FORSTEGANGSTJENESTE_FELTER)
         return { ...updated, _status: status }

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
@@ -99,14 +99,14 @@ export async function action({ params, request }: Route.ActionArgs) {
   const sakIdRaw = formData.get('sakId')
   const payloadRaw = formData.get('payload')
 
-  if (!payloadRaw) {
+  if (typeof payloadRaw !== 'string' || payloadRaw.length === 0) {
     return data({ errors: { _form: 'Mangler skjemadata' } as ActionErrors }, { status: 400 })
   }
 
   let payload: OppdaterOpptjeningVurdering
 
   try {
-    payload = JSON.parse(payloadRaw as string)
+    payload = JSON.parse(payloadRaw)
   } catch {
     return data({ errors: { _form: 'Ugyldig skjemadata' } as ActionErrors }, { status: 400 })
   }

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
@@ -40,7 +40,6 @@ import type {
   OppdaterOpptjeningGrunnlag,
   OppdaterOpptjeningVurdering,
   OpptjeningstyperResponse,
-  VurderingResponse,
 } from './oppdater-grunnlag-types'
 
 export function meta() {
@@ -85,16 +84,9 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     }
   }
 
-  const [vurderingResponse, opptjeningstyper] = await Promise.all([
-    api.hentVurdering<VurderingResponse>(),
-    fetchOpptjeningstyper(request),
-  ])
+  const opptjeningstyper = await fetchOpptjeningstyper(request)
 
-  const savedVurdering: OppdaterOpptjeningVurdering | null = vurderingResponse?.vurdering
-    ? (JSON.parse(vurderingResponse.vurdering) as OppdaterOpptjeningVurdering)
-    : null
-
-  return { grunnlag, savedVurdering, opptjeningstyper, readOnly }
+  return { grunnlag, opptjeningstyper, readOnly }
 }
 
 export type ActionErrors = { _form?: string; _server?: string[] }
@@ -1677,15 +1669,6 @@ export default function OppdaterGrunnlagRoute({ loaderData, actionData }: Route.
                 </Button>
                 <Button type="button" variant="tertiary" size="small" onClick={avbrytAktivitet} disabled={isSubmitting}>
                   Avbryt behandling
-                </Button>
-                {/* DEBUG */}
-                <Button
-                  type="button"
-                  variant="tertiary-neutral"
-                  size="small"
-                  onClick={() => console.log('[DEBUG payload]', JSON.parse(payload))}
-                >
-                  Log payload
                 </Button>
               </HStack>
             </VStack>

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/index.tsx
@@ -143,8 +143,13 @@ export async function action({ params, request }: Route.ActionArgs) {
     ),
   }))
 
+  const sakId = sakIdRaw ? Number(sakIdRaw) : undefined
+  if (sakIdRaw && (isNaN(sakId as number) || !Number.isInteger(sakId))) {
+    return data({ errors: { _form: 'Ugyldig sakId' } as ActionErrors }, { status: 400 })
+  }
+
   const vurdering: OppdaterOpptjeningVurdering = {
-    ...(sakIdRaw ? { sakId: Number(sakIdRaw) } : {}),
+    ...(sakId !== undefined ? { sakId } : {}),
     ...payload,
   }
 
@@ -270,7 +275,8 @@ export function oversettKoderIMelding(melding: string, opptjeningstyper: Opptjen
   ].sort((a, b) => b.code.length - a.code.length)
 
   return alle.reduce((tekst, type) => {
-    const regex = new RegExp(`\\b${type.code}\\b`, 'g')
+    const escaped = type.code.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(`\\b${escaped}\\b`, 'g')
     return tekst.replace(regex, `${type.description} (${type.code})`)
   }, melding)
 }
@@ -1273,7 +1279,8 @@ export default function OppdaterGrunnlagRoute({ loaderData, actionData }: Route.
     setForstegangstjenesteLinjer(prev =>
       prev.map(l => {
         if (l._id !== id) return l
-        const updated: ForstegangstjenesteLinjeState = { ...l, [felt]: verdi || null }
+        const feltVerdi = felt === 'periodeType' ? (verdi || null) : verdi
+        const updated: ForstegangstjenesteLinjeState = { ...l, [felt]: feltVerdi }
         const status = beregnStatus(updated, FORSTEGANGSTJENESTE_FELTER)
         return { ...updated, _status: status }
       }),

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/oppdater-grunnlag-types.ts
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/oppdater-grunnlag-types.ts
@@ -1,4 +1,4 @@
-export type { OpptjeningTypeKode, OpptjeningstyperKategori, OpptjeningstyperResponse } from '~/types/opptjeningstyper'
+export type { OpptjeningstyperKategori, OpptjeningstyperResponse, OpptjeningTypeKode } from '~/types/opptjeningstyper'
 
 export type InntektDTO = {
   inntektId?: number | null

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/oppdater-grunnlag-types.ts
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/oppdater-grunnlag-types.ts
@@ -1,19 +1,4 @@
-export type OpptjeningTypeKode = {
-  code: string
-  description: string
-}
-
-export type OpptjeningstyperKategori = {
-  typer: OpptjeningTypeKode[]
-  subTyper: OpptjeningTypeKode[]
-}
-
-export type OpptjeningstyperResponse = {
-  inntekt: OpptjeningstyperKategori
-  omsorg: OpptjeningstyperKategori
-  dagpenger: OpptjeningstyperKategori
-  forstegangstjeneste: OpptjeningstyperKategori
-}
+export type { OpptjeningTypeKode, OpptjeningstyperKategori, OpptjeningstyperResponse } from '~/types/opptjeningstyper'
 
 export type InntektDTO = {
   inntektId?: number | null

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/oppdater-grunnlag-types.ts
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-grunnlag/oppdater-grunnlag-types.ts
@@ -1,0 +1,134 @@
+export type OpptjeningTypeKode = {
+  code: string
+  description: string
+}
+
+export type OpptjeningstyperKategori = {
+  typer: OpptjeningTypeKode[]
+  subTyper: OpptjeningTypeKode[]
+}
+
+export type OpptjeningstyperResponse = {
+  inntekt: OpptjeningstyperKategori
+  omsorg: OpptjeningstyperKategori
+  dagpenger: OpptjeningstyperKategori
+  forstegangstjeneste: OpptjeningstyperKategori
+}
+
+export type InntektDTO = {
+  inntektId?: number | null
+  kommune?: string | null
+  inntektAr: number
+  belop?: number | null
+  inntektType: string
+}
+
+export type DagpengerDTO = {
+  dagpengerId?: number | null
+  ar: number
+  dagpengerType: string
+  uavkortetDagpengegrunnlag?: number | null
+  utbetalteDagpenger?: number | null
+  ferietillegg?: number | null
+  barnetillegg?: number | null
+}
+
+export type OmsorgDTO = {
+  omsorgId?: number | null
+  ar: number
+  omsorgType: string
+  fnrOmsorgFor?: string | null
+}
+
+export type ForstegangstjenesteDTO = {
+  forstegangstjenesteId?: number | null
+  tjenesteType: string
+  periodeType?: string | null
+  fomDato: string
+  tomDato: string
+}
+
+export type OppdaterPgiSakValg = {
+  sakId: number
+  sakType?: string | null
+  sakStatus?: string | null
+}
+
+export type OppdaterOpptjeningGrunnlag = {
+  saker?: OppdaterPgiSakValg[]
+  kanOppretteGenerellSak?: boolean
+  opptjeningsGrunnlagDto?: {
+    fnr: string | null
+    inntektListe: InntektBackendDTO[]
+    omsorgListe: OmsorgBackendDTO[]
+    dagpengerListe: DagpengerBackendDTO[]
+    forstegangstjeneste?: ForstegangstjenesteBackendDTO | null
+  }
+}
+
+export type OppdaterOpptjeningVurdering = {
+  sakId?: number
+  fnr?: string
+  inntektEndringer?: { endringstype: Endringstype; inntektListe: InntektBackendDTO[] }[]
+  dagpengerEndringer?: { endringstype: Endringstype; dagpengerListe: DagpengerBackendDTO[] }[]
+  omsorgEndringer?: { endringstype: Endringstype; omsorgListe: OmsorgBackendDTO[] }[]
+  forstegangstjenesteEndringer?: { endringstype: Endringstype; forstegangstjeneste: ForstegangstjenesteBackendDTO }[]
+}
+
+export type VurderingResponse = {
+  vurdering: string | null
+  vurdertTidspunkt?: string | null
+  vurdertAvBrukerId?: string | null
+  vurdertAvBrukerNavn?: string | null
+}
+
+export type Endringstype = 'OPPRETT' | 'OPPDATER' | 'SLETT'
+
+export type InntektBackendDTO = {
+  inntektId?: number | null
+  fnr: string
+  kilde?: string | null
+  kommune?: string | null
+  piMerke?: string | null
+  inntektAr: number
+  belop?: string | null
+  inntektType: string
+}
+
+export type DagpengerBackendDTO = {
+  dagpengerId?: number | null
+  fnr: string
+  dagpengerType: string
+  rapportType?: string | null
+  kilde?: string | null
+  ar: number
+  utbetalteDagpenger?: number | null
+  uavkortetDagpengegrunnlag?: number | null
+  ferietillegg?: number | null
+  barnetillegg?: number | null
+}
+
+export type OmsorgBackendDTO = {
+  omsorgId?: number | null
+  fnr: string
+  fnrOmsorgFor?: string | null
+  omsorgType: string
+  kilde?: string | null
+  ar: number
+}
+
+export type ForstegangstjenesteBackendDTO = {
+  forstegangstjenesteId?: number | null
+  fnr: string
+  kilde?: string | null
+  rapportType?: string | null
+  tjenestestartDato?: string | null
+  dimitteringDato?: string | null
+  forstegangstjenestePeriodeListe: {
+    forstegangstjenestePeriodeId?: number | null
+    periodeType?: string | null
+    tjenesteType: string
+    fomDato?: string | null
+    tomDato?: string | null
+  }[]
+}

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-opptjeningsgrunnlag-avbrutt/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/oppdater-opptjeningsgrunnlag-avbrutt/index.tsx
@@ -1,0 +1,25 @@
+import { LocalAlert, Page } from '@navikt/ds-react'
+import { useOutletContext } from 'react-router'
+import styles from '~/common.module.css'
+import type { AktivitetOutletContext } from '~/types/aktivitetOutletContext'
+
+export async function loader() {
+  return {}
+}
+
+export default function OppdaterOpptjeningsgrunnlagAvbruttRoute() {
+  const { behandling } = useOutletContext<AktivitetOutletContext>()
+
+  return (
+    <Page.Block gutters className={`${styles.page} ${styles.center}`}>
+      <LocalAlert status="warning">
+        <LocalAlert.Header>
+          <LocalAlert.Title>Behandlingen er avbrutt</LocalAlert.Title>
+        </LocalAlert.Header>
+        <LocalAlert.Content>
+          Oppdatering av opptjeningsgrunnlag for behandling {behandling.behandlingId} er avbrutt.
+        </LocalAlert.Content>
+      </LocalAlert>
+    </Page.Block>
+  )
+}

--- a/app/behandlinger/oppdater-opptjeningsgrunnlag/send-til-attestering/index.tsx
+++ b/app/behandlinger/oppdater-opptjeningsgrunnlag/send-til-attestering/index.tsx
@@ -1,0 +1,31 @@
+import { redirect, useOutletContext } from 'react-router'
+import { createAktivitetApi } from '~/api/aktivitet-api'
+import { SendTilAttestering } from '~/components/shared/SendTilAttestering'
+import type { AktivitetOutletContext } from '~/types/aktivitetOutletContext'
+import type { Route } from './+types'
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const { behandlingId, aktivitetId } = params
+  createAktivitetApi({ request, behandlingId, aktivitetId })
+  return {}
+}
+
+export async function action({ params, request }: Route.ActionArgs) {
+  const { behandlingId, aktivitetId } = params
+  const api = createAktivitetApi({ request, behandlingId, aktivitetId })
+  await api.lagreVurdering({ sendTilAttestering: true })
+  return redirect(`/behandling/${behandlingId}?justCompleted=${aktivitetId}`)
+}
+
+export default function SendTilAttesteringRoute() {
+  const { avbrytAktivitet } = useOutletContext<AktivitetOutletContext>()
+
+  return (
+    <SendTilAttestering
+      heading="Send til attestering"
+      submitLabel="Send til attestering"
+      cancelLabel="Avbryt behandling"
+      onAvbryt={avbrytAktivitet}
+    />
+  )
+}

--- a/app/components/shared/SendTilAttestering.tsx
+++ b/app/components/shared/SendTilAttestering.tsx
@@ -15,13 +15,13 @@ export function SendTilAttestering({ heading, submitLabel, cancelLabel, onAvbryt
 
   return (
     <Page.Block gutters className={`${styles.page} ${styles.center}`}>
-      <VStack gap="8">
+      <VStack gap="space-32">
         <Heading size="medium" level="2">
           {heading}
         </Heading>
 
         <Form method="post">
-          <VStack gap="2" align="center">
+          <VStack gap="space-8" align="center">
             <Button type="submit" variant="primary" size="small" loading={isSubmitting}>
               {submitLabel}
             </Button>

--- a/app/components/shared/SendTilAttestering.tsx
+++ b/app/components/shared/SendTilAttestering.tsx
@@ -1,0 +1,37 @@
+import { Button, Heading, Page, VStack } from '@navikt/ds-react'
+import { Form } from 'react-router'
+import styles from '~/common.module.css'
+import { useIsSubmitting } from '~/hooks/use-is-submitting'
+
+interface SendTilAttesteringProps {
+  heading: string
+  submitLabel: string
+  cancelLabel: string
+  onAvbryt: () => void
+}
+
+export function SendTilAttestering({ heading, submitLabel, cancelLabel, onAvbryt }: SendTilAttesteringProps) {
+  const isSubmitting = useIsSubmitting()
+
+  return (
+    <Page.Block gutters className={`${styles.page} ${styles.center}`}>
+      <VStack gap="8">
+        <Heading size="medium" level="2">
+          {heading}
+        </Heading>
+
+        <Form method="post">
+          <VStack gap="2" align="center">
+            <Button type="submit" variant="primary" size="small" loading={isSubmitting}>
+              {submitLabel}
+            </Button>
+
+            <Button type="button" variant="tertiary" size="small" onClick={onAvbryt} disabled={isSubmitting}>
+              {cancelLabel}
+            </Button>
+          </VStack>
+        </Form>
+      </VStack>
+    </Page.Block>
+  )
+}

--- a/app/hooks/use-is-submitting.ts
+++ b/app/hooks/use-is-submitting.ts
@@ -1,0 +1,6 @@
+import { useNavigation } from 'react-router'
+
+export function useIsSubmitting() {
+  const navigation = useNavigation()
+  return navigation.state !== 'idle' && navigation.formData != null
+}

--- a/app/mocks/data/aktivitet/14205801-grunnlagsdata.json
+++ b/app/mocks/data/aktivitet/14205801-grunnlagsdata.json
@@ -1,0 +1,75 @@
+{
+  "kanOppretteGenerellSak": true,
+  "opptjeningsGrunnlagDto": {
+    "fnr": "00000000000",
+    "inntektListe": [
+      {
+        "inntektId": 602057004,
+        "kilde": "PEN",
+        "kommune": "1337",
+        "inntektAr": 1995,
+        "belop": "41993",
+        "inntektType": "INN_LON"
+      },
+      {
+        "inntektId": 602057008,
+        "kilde": "PEN",
+        "kommune": "1337",
+        "inntektAr": 2000,
+        "belop": "67195",
+        "inntektType": "INN_LON"
+      },
+      {
+        "inntektId": 602057030,
+        "kilde": "PEN",
+        "kommune": "1337",
+        "inntektAr": 2023,
+        "belop": "160526",
+        "inntektType": "INN_LON"
+      },
+      {
+        "inntektId": 602057032,
+        "kilde": "PEN",
+        "kommune": "1337",
+        "inntektAr": 2025,
+        "belop": "170906",
+        "inntektType": "INN_LON"
+      }
+    ],
+    "dagpengerListe": [
+      {
+        "dagpengerId": 702057001,
+        "kilde": "PEN",
+        "ar": 2020,
+        "dagpengerType": "DP",
+        "uavkortetDagpengegrunnlag": 350000,
+        "utbetalteDagpenger": 185000,
+        "ferietillegg": 12000,
+        "barnetillegg": 0
+      }
+    ],
+    "omsorgListe": [
+      {
+        "omsorgId": 802057001,
+        "kilde": "PEN",
+        "ar": 2010,
+        "omsorgType": "OBU6"
+      }
+    ],
+    "forstegangstjeneste": {
+      "forstegangstjenesteId": 902057001,
+      "kilde": "PEN",
+      "tjenestestartDato": "2012-01-15",
+      "dimitteringDato": "2012-12-31",
+      "forstegangstjenestePeriodeListe": [
+        {
+          "forstegangstjenestePeriodeId": 1,
+          "periodeType": "NORMAL",
+          "tjenesteType": "MIL",
+          "fomDato": "2012-01-15",
+          "tomDato": "2012-12-31"
+        }
+      ]
+    }
+  }
+}

--- a/app/mocks/data/opptjeningstyper.json
+++ b/app/mocks/data/opptjeningstyper.json
@@ -1,0 +1,77 @@
+{
+  "inntekt": {
+    "typer": [
+      { "code": "AI", "description": "Antatt inntekt" },
+      { "code": "DIP_JSF", "description": "Diplomatinntekt - Jord/Skog/Fisk" },
+      { "code": "DIP_LON", "description": "Diplomatinntekt - Lønn" },
+      { "code": "DIP_SEL", "description": "Diplomatinntekt - Selvstendig" },
+      { "code": "FL_PGI_LOENN", "description": "Fastland - Lønnsinntekt" },
+      { "code": "FL_PGI_LOENN_PD", "description": "Fastland - Lønnsinntekt - Bare pensjonsdel" },
+      { "code": "FL_PGI_NAERING", "description": "Fastland - Næringsinntekt" },
+      {
+        "code": "FL_PGI_NAERING_FFF",
+        "description": "Fastland - Næringsinntekt - Fiske, fangst eller familiebarnehage"
+      },
+      { "code": "INN_JSF", "description": "Innenlandsinntekt - Jord/Skog/Fisk" },
+      { "code": "INN_LON", "description": "Innenlandsinntekt - Lønn" },
+      { "code": "INN_SEL", "description": "Innenlandsinntekt - Selvstendig" },
+      { "code": "KSL_PGI_LOENN", "description": "Kildeskatt - Lønnsinntekt" },
+      { "code": "KSL_PGI_LOENN_PD", "description": "Kildeskatt - Lønnsinntekt - Bare pensjonsdel" },
+      { "code": "KSL_PGI_NAERING", "description": "Kildeskatt - Næringsinntekt" },
+      {
+        "code": "KSL_PGI_NAERING_FFF",
+        "description": "Kildeskatt - Næringsinntekt - Fiske, fangst eller familiebarnehage"
+      },
+      { "code": "PGI_NAV", "description": "PGI innland fastsatt av NAV" },
+      { "code": "PI66", "description": "Pensjonsgivende inntekt 1966 - Konv" },
+      { "code": "RED_INT", "description": "Reduksjonsinntekt" },
+      { "code": "SJO_JSF", "description": "Sjøinntekt - Jord/Skog/Fisk" },
+      { "code": "SJO_LON", "description": "Sjøinntekt - Lønn" },
+      { "code": "SJO_SEL", "description": "Sjøinntekt - Selvstendig" },
+      { "code": "SUM_PI", "description": "Sum pensjonsgivende inntekt" },
+      { "code": "SVA_JSF", "description": "Svalbardinntekt - Jord/Skog/Fisk" },
+      { "code": "SVA_LON", "description": "Svalbardinntekt - Lønn" },
+      { "code": "SVA_PGI_LOENN", "description": "Svalbard - Lønnsinntekt" },
+      { "code": "SVA_PGI_LOENN_PD", "description": "Svalbard - Lønnsinntekt - Bare pensjonsdel" },
+      { "code": "SVA_PGI_NAERING", "description": "Svalbard - Næringsinntekt" },
+      {
+        "code": "SVA_PGI_NAERING_FFF",
+        "description": "Svalbard - Næringsinntekt - Fiske, fangst eller familiebarnehage"
+      },
+      { "code": "SVA_SEL", "description": "Svalbardinntekt - Selvstendig" },
+      { "code": "UTE_JSF", "description": "Utenlandsinntekt - Jord/Skog/Fisk" },
+      { "code": "UTE_LON", "description": "Utenlandsinntekt - Lønn" },
+      { "code": "UTE_SEL", "description": "Utenlandsinntekt - Selvstendig" }
+    ],
+    "subTyper": []
+  },
+  "omsorg": {
+    "typer": [
+      { "code": "OBO6H", "description": "Omsorg for barn over 6 år med hjelpestønad sats 3 eller 4" },
+      { "code": "OBO7H", "description": "Omsorg for barn over 7 år med hjelpestønad sats 3 eller 4" },
+      { "code": "OBU6", "description": "Omsorg for barn under 6 år" },
+      { "code": "OBU7", "description": "Omsorg for barn under 7 år" },
+      { "code": "OSFE", "description": "Omsorg for syke/funksjonshemmede/eldre" }
+    ],
+    "subTyper": []
+  },
+  "dagpenger": {
+    "typer": [
+      { "code": "DP", "description": "Dagpengeopptjening" },
+      { "code": "DP_FF", "description": "Dagpengeopptjening for fiskere og fangstmenn" }
+    ],
+    "subTyper": []
+  },
+  "forstegangstjeneste": {
+    "typer": [
+      { "code": "SIV", "description": "Sivil førstegangstjeneste" },
+      { "code": "MIL", "description": "Militær førstegangstjeneste" }
+    ],
+    "subTyper": [
+      { "code": "BEFAL", "description": "Befalsskole" },
+      { "code": "NORMAL", "description": "Normal avtjening" },
+      { "code": "TEKN", "description": "Teknisk utdanning" },
+      { "code": "UKJENT", "description": "Ikke oppgitt" }
+    ]
+  }
+}

--- a/app/mocks/index.ts
+++ b/app/mocks/index.ts
@@ -10,6 +10,7 @@ let isInitialized = false
 function shouldEnableMocking(): boolean {
   return (
     isServer &&
+    !process.env.NAIS_CLUSTER_NAME &&
     (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'mock' || process.env.ENABLE_MOCKING === 'true')
   )
 }

--- a/app/mocks/server.ts
+++ b/app/mocks/server.ts
@@ -203,6 +203,16 @@ const handlers = [
     console.log(`🎯 MSW intercepted POST returner for behandling ${params.behandlingId}`)
     return HttpResponse.json({ ok: true })
   }),
+
+  // GET /api/saksbehandling/oppdater-opptjeningsgrunnlag/opptjeningstyper
+  http.get('*/api/saksbehandling/oppdater-opptjeningsgrunnlag/opptjeningstyper', ({ request }) => {
+    console.log(`🎯 MSW intercepted request to: ${request.url}`)
+    const mockData = loadMockData('opptjeningstyper.json')
+    if (mockData) {
+      return HttpResponse.json(mockData)
+    }
+    return HttpResponse.text('Not found', { status: 404 })
+  }),
 ]
 
 // Create and export the server

--- a/app/types/behandling.ts
+++ b/app/types/behandling.ts
@@ -15,6 +15,7 @@ export enum BehandlingStatus {
   STOPPET = 'STOPPET',
   UTSATT = 'UTSATT',
   UNDER_BEHANDLING = 'UNDER_BEHANDLING',
+  DEBUG = 'DEBUG',
 }
 
 export enum AktivitetStatus {

--- a/app/types/behandling.ts
+++ b/app/types/behandling.ts
@@ -15,7 +15,6 @@ export enum BehandlingStatus {
   STOPPET = 'STOPPET',
   UTSATT = 'UTSATT',
   UNDER_BEHANDLING = 'UNDER_BEHANDLING',
-  DEBUG = 'DEBUG',
 }
 
 export enum AktivitetStatus {

--- a/app/types/opptjeningstyper.ts
+++ b/app/types/opptjeningstyper.ts
@@ -1,0 +1,16 @@
+export type OpptjeningTypeKode = {
+  code: string
+  description: string
+}
+
+export type OpptjeningstyperKategori = {
+  typer: OpptjeningTypeKode[]
+  subTyper: OpptjeningTypeKode[]
+}
+
+export type OpptjeningstyperResponse = {
+  inntekt: OpptjeningstyperKategori
+  omsorg: OpptjeningstyperKategori
+  dagpenger: OpptjeningstyperKategori
+  forstegangstjeneste: OpptjeningstyperKategori
+}


### PR DESCRIPTION
## Hva
Implementerer UI for behandlingstypen `oppdater-opptjeningsgrunnlag`.

## Endringer
- `oppdater-grunnlag/`: skjema for å oppdatere grunnlag med opptjeningstyper fra pen (~1700 linjer + 843 linjer tester)
- `attester/`: attestering av oppdateringen
- `send-til-attestering/`: send-til-attestering for denne behandlingstypen
- `oppdater-opptjeningsgrunnlag-avbrutt/`: avbrutt-tilstand
- `opptjeningstyper-api.server.ts`: API-kall mot pen (/opptjeningstyper)
- Mock-data for aktivitet 14205801 og opptjeningstyper
- Ny behandling-type i types/behandling.ts

## Avhengigheter
Merges **etter**:
1. `refactor/api-client` — bruker refaktorert api-client og error types
2. `feat/psak-url-og-pid-kryptering` — bruker psak-url utilities
3. `refactor/delte-komponenter-og-hooks` — bruker SendTilAttestering og useIsSubmitting

## Erstatter
Denne branchen erstatter `feature/oppdater-opptjeningsgrunnlag` (PR #160) som inneholdt mange uavhengige endringer.